### PR TITLE
Add Support for Localizing Magic Links

### DIFF
--- a/Sources/Passage/PassageAPIClient/PassageAPIClient.swift
+++ b/Sources/Passage/PassageAPIClient/PassageAPIClient.swift
@@ -347,19 +347,21 @@ internal class PassageAPIClient : PassageAuthAPIClient {
     /// - Parameters:
     ///   - identifier: The users email or phone number
     ///   - path: optional path to append to the redirect url
+    ///   - language: optional language string for localizing emails, if no lanuage or an invalid language is provided the application default lanuage will be used
     /// - Returns: ``MagicLink``
     /// - Throws: ``PassageAPIError``
-    internal func sendLoginMagicLink(identifier: String, path: String?) async throws -> MagicLink {
+    internal func sendLoginMagicLink(identifier: String, path: String?, language: String? = nil) async throws -> MagicLink {
         let url = try self.appUrl(path: "login/magic-link/")
         var request = URLRequest(url: url, cachePolicy: .reloadIgnoringCacheData)
         
-        var data: Data
+        var jsonObject = ["identifier": identifier]
         if ( path != nil) {
-            data = try JSONSerialization.data(withJSONObject: ["identifier": identifier, path: path], options: [])
+            jsonObject["path"] = path
         }
-        else {
-            data = try JSONSerialization.data(withJSONObject: ["identifier": identifier], options: [])
+        if ( language != nil) {
+            jsonObject["language"] = language
         }
+        let data = try JSONSerialization.data(withJSONObject: jsonObject, options: [])
         
         request.httpMethod = "POST"
         
@@ -376,19 +378,21 @@ internal class PassageAPIClient : PassageAuthAPIClient {
     /// - Parameters:
     ///   - identifier: The users email or phone number
     ///   - path: optional path to append to the redirect url
+    ///   - language: optional language string for localizing emails, if no lanuage or an invalid language is provided the application default lanuage will be used
     /// - Returns: ``MagicLink``
-    internal func sendRegisterMagicLink(identifier: String, path: String?) async throws -> MagicLink {
+    internal func sendRegisterMagicLink(identifier: String, path: String?, language: String? = nil) async throws -> MagicLink {
         let url = try self.appUrl(path: "register/magic-link/")
         
         var request = URLRequest(url: url, cachePolicy: .reloadIgnoringCacheData)
         
-        var data: Data
+        var jsonObject = ["identifier": identifier]
         if ( path != nil) {
-            data = try JSONSerialization.data(withJSONObject: ["identifier": identifier, path: path], options: [])
+            jsonObject["path"] = path
         }
-        else {
-            data = try JSONSerialization.data(withJSONObject: ["identifier": identifier], options: [])
+        if ( language != nil) {
+            jsonObject["language"] = language
         }
+        let data = try JSONSerialization.data(withJSONObject: jsonObject, options: [])
         
         request.httpMethod = "POST"
         
@@ -501,9 +505,10 @@ internal class PassageAPIClient : PassageAuthAPIClient {
     ///   - newEmail: New email address
     ///   - magicLinkPath: optional path to append to the redirect url
     ///   - redirectUrl: optional path to append to the redirect url
+    ///   - language: optional language string for localizing emails, if no lanuage or an invalid language is provided the application default lanuage will be used
     /// - Returns: ``MagicLink``
     /// - Throws: ``PassageAPIError``
-    internal func changeEmail(token: String, newEmail: String, magicLinkPath: String?, redirectUrl: String?) async throws -> MagicLink {
+    internal func changeEmail(token: String, newEmail: String, magicLinkPath: String?, redirectUrl: String?, language: String?) async throws -> MagicLink {
         let url = try self.appUrl(path: "currentuser/email/")
         
         var request = URLRequest(url: url, cachePolicy: .reloadIgnoringCacheData)
@@ -513,19 +518,17 @@ internal class PassageAPIClient : PassageAuthAPIClient {
         
         request.httpMethod = "PATCH"
         
-        var data: Data
-        if ( magicLinkPath != nil && redirectUrl != nil) {
-            data = try JSONSerialization.data(withJSONObject: ["new_email": newEmail, "magic_link_path": magicLinkPath, "redirect_url": redirectUrl], options: [])
+        var jsonObject = ["new_email": newEmail]
+        if (redirectUrl != nil) {
+            jsonObject["redirect_url"] = redirectUrl
         }
-        else if ( magicLinkPath != nil) {
-            data = try JSONSerialization.data(withJSONObject: ["new_email": newEmail, "magic_link_path": magicLinkPath], options: [])
+        if (magicLinkPath != nil) {
+            jsonObject["magic_link_path"] = magicLinkPath
         }
-        else if ( redirectUrl != nil ) {
-            data = try JSONSerialization.data(withJSONObject: ["new_email": newEmail,  "redirect_url": redirectUrl], options: [])
+        if(language != nil) {
+            jsonObject["language"] = language
         }
-        else {
-            data = try JSONSerialization.data(withJSONObject: ["new_email": newEmail], options: [])
-        }
+        let data = try JSONSerialization.data(withJSONObject: jsonObject, options: [])
         
         let (responseData, response) = try await URLSession.shared.upload(for: request, from: data)
         
@@ -543,9 +546,10 @@ internal class PassageAPIClient : PassageAuthAPIClient {
     ///   - newPhone: The user's new phone number
     ///   - magicLinkPath: optional path to append to the redirect url
     ///   - redirectUrl: optional path to append to the redirect url
+    ///   - language: optional language string for localizing emails, if no lanuage or an invalid language is provided the application default lanuage will be used
     /// - Returns: ``MagicLink``
     /// - Throws: ``PassageAPIError``
-    internal func changePhone(token: String, newPhone: String, magicLinkPath: String?, redirectUrl: String?) async throws -> MagicLink {
+    internal func changePhone(token: String, newPhone: String, magicLinkPath: String?, redirectUrl: String?, language: String?) async throws -> MagicLink {
         
       let url = try self.appUrl(path: "currentuser/phone/")
       var request = URLRequest(url: url, cachePolicy: .reloadIgnoringCacheData)
@@ -554,20 +558,19 @@ internal class PassageAPIClient : PassageAuthAPIClient {
       request.addValue("\(tokenString)", forHTTPHeaderField: "Authorization")
       
       request.httpMethod = "PATCH"
-      
-      var data: Data
-      if ( magicLinkPath != nil && redirectUrl != nil) {
-          data = try JSONSerialization.data(withJSONObject: ["new_phone": newPhone, "magic_link_path": magicLinkPath, "redirect_url": redirectUrl], options: [])
+        
+      var jsonObject = ["new_phone": newPhone]
+        
+      if (redirectUrl != nil) {
+          jsonObject["redirect_url"] = redirectUrl
       }
-      else if ( magicLinkPath != nil) {
-          data = try JSONSerialization.data(withJSONObject: ["new_phone": newPhone, "magic_link_path": magicLinkPath], options: [])
+      if (magicLinkPath != nil) {
+          jsonObject["magic_link_path"] = magicLinkPath
       }
-      else if ( redirectUrl != nil ) {
-          data = try JSONSerialization.data(withJSONObject: ["new_phone": newPhone,  "redirect_url": redirectUrl], options: [])
+      if(language != nil) {
+          jsonObject["language"] = language
       }
-      else {
-          data = try JSONSerialization.data(withJSONObject: ["new_phone": newPhone,], options: [])
-      }
+      let data = try JSONSerialization.data(withJSONObject: jsonObject, options: [])
       
       let (responseData, response) = try await URLSession.shared.upload(for: request, from: data)
       

--- a/Sources/Passage/PassageAPIClient/PassageAPIClientProtocol.swift
+++ b/Sources/Passage/PassageAPIClient/PassageAPIClientProtocol.swift
@@ -97,16 +97,18 @@ protocol PassageAuthAPIClient  {
     /// - Parameters:
     ///   - identifier: The users email or phone number
     ///   - path: optional path to append to the redirect url
+    ///   - language: optional language string for localizing emails, if no lanuage or an invalid language is provided the application default lanuage will be used
     /// - Returns: ``MagicLink``
-    func sendLoginMagicLink(identifier: String, path: String?) async throws -> MagicLink
+    func sendLoginMagicLink(identifier: String, path: String?, language: String?) async throws -> MagicLink
     
     
     /// Send a new registration magic link to the users email or phone
     /// - Parameters:
     ///   - identifier: The users email or phone number
     ///   - path: optional path to append to the redirect url
+    ///   - language: optional language string for localizing emails, if no lanuage or an invalid language is provided the application default lanuage will be used
     /// - Returns: ``MagicLink``
-    func sendRegisterMagicLink(identifier: String, path: String?) async throws -> MagicLink
+    func sendRegisterMagicLink(identifier: String, path: String?, language: String?) async throws -> MagicLink
     
     
     /// Check the status of a magic link
@@ -139,8 +141,9 @@ protocol PassageAuthAPIClient  {
     ///   - newEmail: New email address
     ///   - magicLinkPath: optional path to append to the redirect url
     ///   - redirectUrl: optional path to append to the redirect url
+    ///   - language: optional language string for localizing emails, if no lanuage or an invalid language is provided the application default lanuage will be used
     /// - Returns: ``MagicLink``
-    func changeEmail(token: String, newEmail: String, magicLinkPath: String?, redirectUrl: String?) async throws -> MagicLink
+    func changeEmail(token: String, newEmail: String, magicLinkPath: String?, redirectUrl: String?, language: String?) async throws -> MagicLink
 
     
     /// Change the current user's phone, will send a magic link to confirm
@@ -149,8 +152,9 @@ protocol PassageAuthAPIClient  {
     ///   - newPhone: The user's new phone number
     ///   - magicLinkPath: optional path to append to the redirect url
     ///   - redirectUrl: optional path to append to the redirect url
+    ///   - language: optional language string for localizing emails, if no lanuage or an invalid language is provided the application default lanuage will be used
     /// - Returns: ``MagicLink``
-    func changePhone(token: String, newPhone: String, magicLinkPath: String?, redirectUrl: String?) async throws -> MagicLink
+    func changePhone(token: String, newPhone: String, magicLinkPath: String?, redirectUrl: String?, language: String?) async throws -> MagicLink
     
     
     /// Update the user's device, only supports the friendly name currently

--- a/Sources/Passage/PassageAuth.swift
+++ b/Sources/Passage/PassageAuth.swift
@@ -336,13 +336,14 @@ public class PassageAuth {
     ///
     /// - Parameters:
     ///   - newEmail: string - valid email address
+    ///   - language: optional language string for localizing emails, if no lanuage or an invalid language is provided the application default lanuage will be used
     /// - Returns: ``MagicLink``
     /// - Throws: ``PassageAPIError``, ``PassageError``
-    private func changeEmail(newEmail: String) async throws -> MagicLink? {
+    private func changeEmail(newEmail: String, language: String? = nil) async throws -> MagicLink? {
         guard let token = self.tokenStore.authToken else {
             throw PassageError.unauthorized
         }
-        let magicLink = try await PassageAuth.changeEmail(token: token, newEmail: newEmail)
+        let magicLink = try await PassageAuth.changeEmail(token: token, newEmail: newEmail, language: language)
         return magicLink
     }
     
@@ -354,13 +355,14 @@ public class PassageAuth {
     ///
     /// - Parameters:
     ///   - newPhone: string - valid E164 formatted phone number.
+    ///   - language: optional language string for localizing emails, if no lanuage or an invalid language is provided the application default lanuage will be used
     /// - Returns: ``MagicLink``
     /// - Throws: ``PassageAPIError``, ``PassageError``
-    private  func changePhone(newPhone: String) async throws -> MagicLink? {
+    private  func changePhone(newPhone: String, language: String? = nil) async throws -> MagicLink? {
         guard let token = self.tokenStore.authToken else {
             throw PassageError.unauthorized
         }
-        let magicLink = try await PassageAuth.changePhone(token: token, newPhone: newPhone)
+        let magicLink = try await PassageAuth.changePhone(token: token, newPhone: newPhone, language: language)
         return magicLink
     }
     
@@ -607,12 +609,13 @@ public class PassageAuth {
     ///
     /// - Parameters:
     ///   - identifier: string - email or phone number, depending on your app settings
+    ///   - language: optional language string for localizing emails, if no lanuage or an invalid language is provided the application default lanuage will be used
     /// - Returns: ``MagicLink``
     /// - Throws: ``PassageAPIError``, ``PassageError``
-    public static func loginWithMagicLink(identifier: String) async throws -> MagicLink {
+    public static func loginWithMagicLink(identifier: String, language: String? = nil) async throws -> MagicLink {
         var magicLink: MagicLink?
         do {
-            magicLink = try await PassageAuth.newLoginMagicLink(identifier: identifier)
+            magicLink = try await PassageAuth.newLoginMagicLink(identifier: identifier, language: language)
         } catch (let error as PassageAPIError) {
             try PassageAuth.handlePassageAPIError(error: error)
         } catch {
@@ -705,12 +708,13 @@ public class PassageAuth {
     ///
     /// - Parameters:
     ///   - identifier: string - email or phone number, depending on your app settings
+    ///   - language: optional language string for localizing emails, if no lanuage or an invalid language is provided the application default lanuage will be used
     /// - Returns: ``MagicLink`` This type include the magic link ID, which can be used to check if the magic link has been activate or not, using the getMagicLinkStatus() method
     /// - Throws: ``PassageAPIError``, ``PassageError``
-    public static func newRegisterMagicLink(identifier: String) async throws -> MagicLink {
+    public static func newRegisterMagicLink(identifier: String, language: String? = nil) async throws -> MagicLink {
         var magicLink: MagicLink?
         do {
-            magicLink = try await PassageAPIClient.shared.sendRegisterMagicLink(identifier: identifier, path: nil)
+            magicLink = try await PassageAPIClient.shared.sendRegisterMagicLink(identifier: identifier, path: nil, language: language)
         } catch (let error as PassageAPIError) {
             try PassageAuth.handlePassageAPIError(error: error)
         } catch {
@@ -727,12 +731,13 @@ public class PassageAuth {
     /// Creates and send a magic link to login the user. The user will receive an email or text to complete the login.
     /// - Parameters:
     ///   - identifier: string - email or phone number, depending on your app settings
+    ///   - language: optional language string for localizing emails, if no lanuage or an invalid language is provided the application default lanuage will be used
     /// - Returns: ``MagicLink`` This type include the magic link ID, which can be used to check if the magic link has been activate or not, using the getMagicLinkStatus() method.
     /// - Throws: ``PassageAPIError``, ``PassageError``
-    public static func newLoginMagicLink(identifier: String) async throws -> MagicLink {
+    public static func newLoginMagicLink(identifier: String, language: String? = nil) async throws -> MagicLink {
         var magicLink: MagicLink?
         do {
-            magicLink = try await PassageAPIClient.shared.sendLoginMagicLink(identifier: identifier, path: nil)
+            magicLink = try await PassageAPIClient.shared.sendLoginMagicLink(identifier: identifier, path: nil, language: language)
         } catch (let error as PassageAPIError) {
             try PassageAuth.handlePassageAPIError(error: error)
         } catch {
@@ -923,7 +928,7 @@ public class PassageAuth {
     /// - Returns: Current authToken and an optional refresh token, if being used
     /// - Throws: ``PassageAPIError``, ``PassageSessionError``
     public static func getAuthToken(authToken: String, refreshToken: String?) async throws -> (authToken: String, refreshToken: String?){
-        var isTokenExpired = PassageTokenUtils(token: authToken).isExpired
+        let isTokenExpired = PassageTokenUtils(token: authToken).isExpired
         if(!isTokenExpired){
             return (authToken, refreshToken)
         }
@@ -963,12 +968,13 @@ public class PassageAuth {
     /// - Parameters:
     ///   - token: The user's auth token
     ///   - newEmail: string - valid email address
+    ///   - language: optional language string for localizing emails, if no lanuage or an invalid language is provided the application default lanuage will be used
     /// - Returns: ``MagicLink``
     /// - Throws: ``PassageAPIError``, ``PassageError``
-    private static func changeEmail(token: String, newEmail: String) async throws -> MagicLink {
+    private static func changeEmail(token: String, newEmail: String, language: String? = nil) async throws -> MagicLink {
         var magicLink: MagicLink?
         do {
-            magicLink = try await PassageAPIClient.shared.changeEmail(token: token, newEmail: newEmail, magicLinkPath: nil, redirectUrl: nil)
+            magicLink = try await PassageAPIClient.shared.changeEmail(token: token, newEmail: newEmail, magicLinkPath: nil, redirectUrl: nil, language: language)
         } catch (let error as PassageAPIError) {
             try PassageAuth.handlePassageAPIError(error: error)
         } catch {
@@ -988,12 +994,13 @@ public class PassageAuth {
     /// - Parameters:
     ///   - token: The user's auth token
     ///   - newPhone: string - valid E164 formatted phone number.
+    ///   - language: optional language string for localizing emails, if no lanuage or an invalid language is provided the application default lanuage will be used
     /// - Returns: ``MagicLink``
     /// - Throws: ``PassageAPIError``, ``PassageError``
-    private static func changePhone(token: String, newPhone: String) async throws -> MagicLink {
+    private static func changePhone(token: String, newPhone: String, language: String? = nil) async throws -> MagicLink {
         var magicLink: MagicLink?
         do {
-            magicLink = try await PassageAPIClient.shared.changePhone(token: token, newPhone: newPhone, magicLinkPath: nil, redirectUrl: nil)
+            magicLink = try await PassageAPIClient.shared.changePhone(token: token, newPhone: newPhone, magicLinkPath: nil, redirectUrl: nil, language: language)
         } catch (let error as PassageAPIError) {
             try PassageAuth.handlePassageAPIError(error: error)
         } catch {

--- a/Tests/PassageTests/MockPassageAPIClient.swift
+++ b/Tests/PassageTests/MockPassageAPIClient.swift
@@ -53,14 +53,14 @@ final class MockPassageAPIClient: PassageAuthAPIClient {
         throw PassageError.unknown
     }
     
-    func sendLoginMagicLink(identifier: String, path: String?) async throws -> Passage.MagicLink {
+    func sendLoginMagicLink(identifier: String, path: String?, language: String? = nil) async throws -> Passage.MagicLink {
         guard identifier == "registered-test-user@passage.id" else {
             throw PassageError.unknown
         }
         return Passage.MagicLink(id: "TEST_MAGIC_LINK")
     }
     
-    func sendRegisterMagicLink(identifier: String, path: String?) async throws -> Passage.MagicLink {
+    func sendRegisterMagicLink(identifier: String, path: String?, language: String? = nil) async throws -> Passage.MagicLink {
         guard identifier == "unregistered-test-user@passage.id" else {
             throw PassageError.userAlreadyExists
         }
@@ -83,11 +83,11 @@ final class MockPassageAPIClient: PassageAuthAPIClient {
         throw PassageError.unknown
     }
     
-    func changeEmail(token: String, newEmail: String, magicLinkPath: String?, redirectUrl: String?) async throws -> Passage.MagicLink {
+    func changeEmail(token: String, newEmail: String, magicLinkPath: String?, redirectUrl: String?, language: String?) async throws -> Passage.MagicLink {
         throw PassageError.unknown
     }
     
-    func changePhone(token: String, newPhone: String, magicLinkPath: String?, redirectUrl: String?) async throws -> Passage.MagicLink {
+    func changePhone(token: String, newPhone: String, magicLinkPath: String?, redirectUrl: String?, language: String?) async throws -> Passage.MagicLink {
         throw PassageError.unknown
     }
     


### PR DESCRIPTION
### Description
passage-ios should support passing a language field to functions that generate magic links so they can be localized in the same manner as the equivalent functions in passage-js. 

### Features Impacted
- newLoginMagicLink
- newRegisterMagicLink
- changeEmail
- changePhone

Given that this is an optional parameter the client-facing functions have been updated in a way that will be backwards-compatible with previous versions of passage-ios.

### Testing
Used a local build of the passage UAT test app to confirm localization parameter was being used to send proper localized emails.