### PR TITLE
Test sending login & register links, and their statuses

### DIFF
--- a/Tests/Integration/PassageAPIClient/MagicLinkTests.swift
+++ b/Tests/Integration/PassageAPIClient/MagicLinkTests.swift
@@ -1,0 +1,59 @@
+//
+//  MagicLinkTests.swift
+//  
+//
+//  Created by Kevin Flanagan on 2/16/23.
+//
+import XCTest
+@testable import Passage
+
+final class MagicLinkTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        PassageSettings.shared.apiUrl = apiUrl
+        PassageSettings.shared.appId = appInfoValid.id
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    @available(iOS 15.0, *)
+    func testSendRegisterMagicLink() async {
+        do {
+            PassageAPIClient.shared.appId = appInfoValid.id
+            let date = Date().timeIntervalSince1970
+            let identifier = "authentigator" + "+" + String(date) + "@passage.id"
+            let response = try await PassageAPIClient.shared.sendRegisterMagicLink(identifier: identifier, path: nil, language: nil)
+            print(response)
+            do {
+                _ = try await PassageAPIClient.shared.magicLinkStatus(id: response.id)
+                XCTAssertTrue(false) // the status should error as it is unactivated
+            } catch {
+                XCTAssertTrue(true)
+            }
+            
+        } catch {
+            XCTAssertTrue(false)
+        }
+    }
+    
+    func testSendLoginMagicLink() async {
+        do {
+            PassageAPIClient.shared.appId = appInfoValid.id
+            let response = try await PassageAPIClient.shared.sendLoginMagicLink(identifier: registeredUser.email!, path: nil, language: nil)
+            do {
+                _ = try await PassageAPIClient.shared.magicLinkStatus(id: response.id)
+                XCTAssertTrue(false) // the status should error as it is unactivated
+            } catch {
+                XCTAssertTrue(true)
+            }
+            
+        } catch {
+            print(error)
+            XCTAssertTrue(false)
+        }
+    }
+}
+


### PR DESCRIPTION
## Description
Add integration tests for sending login & register magic links. Also check the status of each link id to confirm that the magic link was sent and the status can be queried. 

Only tests that links are sent, not testing activation yet.