### PR TITLE
Call Refresh and Sign Out Functions on a Session

### DIFF
--- a/Tests/Integration/IntegrationTestData.swift
+++ b/Tests/Integration/IntegrationTestData.swift
@@ -75,6 +75,21 @@ let appInfoInvalid = AppInfo(
     public_signup: true
 )
 
+let appInfoRefreshToken = AppInfo(
+    id: "uFZlFit7nglPuzcYRVesCUBZ",
+    ephemeral: false,
+    name: "passage-ios uat refresh tokens",
+    redirect_url: "/dashboard",
+    login_url: "/",
+    allowed_identifier: "both",
+    required_identifier: "both",
+    auth_origin: "http://localhost:4173",
+    require_email_verification: false,
+    require_identifier_verification: false,
+    session_timeout_length: 5,
+    public_signup: true
+)
+
 
 
 

--- a/Tests/Integration/MailosaurClient.swift
+++ b/Tests/Integration/MailosaurClient.swift
@@ -82,7 +82,6 @@ internal class MailosaurAPIClient {
             guard let magicLink = components!.queryItems?.filter({$0.name == "psg_magic_link"}).first?.value else {
                 return ""
             }
-            print(magicLink)
             return magicLink
         } catch {
             print(error)

--- a/Tests/Integration/PassageAPIClient/SessionTests.swift
+++ b/Tests/Integration/PassageAPIClient/SessionTests.swift
@@ -1,0 +1,66 @@
+//
+//  SessionTests.swift
+//
+//
+//  Created by Kevin Flanagan on 2/21/23.
+//
+import XCTest
+@testable import Passage
+
+final class SessionTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        PassageSettings.shared.apiUrl = apiUrl
+        PassageSettings.shared.appId = appInfoRefreshToken.id
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    
+    func testRefreshAndSignOut() async {
+        do{
+            // Sign in and get tokens
+            PassageAPIClient.shared.appId = appInfoRefreshToken.id
+            let date = Date().timeIntervalSince1970
+            let identifier = "authentigator" + "+" + String(date) + "@ncor7c1m.mailosaur.net"
+            _ = try await PassageAPIClient.shared.sendRegisterMagicLink(identifier: identifier, path: nil, language: nil)
+            try await Task.sleep(nanoseconds: UInt64(3 * Double(NSEC_PER_SEC)))
+            let magicLink = try await MailosaurAPIClient().getMostRecentMagicLink()
+            let tokens = try await PassageAPIClient.shared.activateMagicLink(magicLink: magicLink)
+            XCTAssertNotNil(tokens.refresh_token)
+            
+            // Refresh the tokens
+            let newTokens = try await PassageAPIClient.shared.refresh(refreshToken: tokens.refresh_token!)
+            XCTAssertNotNil(newTokens.auth_token)
+            XCTAssertNotNil(newTokens.refresh_token)
+            XCTAssertFalse(newTokens.refresh_token == tokens.refresh_token)
+            
+            // Sign out the session
+            try await PassageAPIClient.shared.signOut(refreshToken: newTokens.refresh_token!)
+            try await Task.sleep(nanoseconds: UInt64(Double(appInfoRefreshToken.session_timeout_length) * Double(NSEC_PER_SEC)))
+            do {
+                _ = try await PassageAPIClient.shared.currentUser(token: newTokens.auth_token!)
+                XCTAssertTrue(false) // the above function should throw an unauthenticated exception
+            } catch {
+                XCTAssertTrue(error is PassageAPIError)
+                
+                if let thrownError = error as? PassageAPIError {
+                    switch thrownError {
+                        case .unauthorized( _ ):
+                            XCTAssertTrue(true)
+                    default:
+                        XCTAssertFalse(true)
+                    }
+                }
+            }
+
+        } catch {
+            print(error)
+            XCTAssertTrue(false)
+        }
+    }
+}
+


### PR DESCRIPTION
## Description
We want to test that refresh and sign out functions are working as expected.

## Implementation
- Since we need a short-lived token I set up a a new testing app on the UAT environment. Refresh tokens are enabled and the auth token timeout is set to the minimum of 5 seconds.
- To get a current set of tokens we register a new user and activate via magic link
- With that set of token call refresh and validate results
- Then call signOut, wait for the auth token to expire, and validate that the token is now invalid

## Testing
- Runs locally
- Runs in CI