### PR TITLE
Psg 1556

### DIFF
--- a/Passage.podspec
+++ b/Passage.podspec
@@ -11,5 +11,5 @@ Pod::Spec.new do |s|
     s.source_files = 'Sources/Passage/**/*'
     s.exclude_files = ['Sources/Passage/Passage.docc/**/*', 'docs']
     s.dependency 'SwiftKeychainWrapper'
-    s.resources = "Sources/Passage/Resources/settings.json"
+
 end

--- a/Sources/Passage/PassageSettings.swift
+++ b/Sources/Passage/PassageSettings.swift
@@ -58,6 +58,7 @@ internal class PassageSettings : PassageAuthSettings {
             }
         }
         
+        #if SWIFT_PACKAGE
         do {
             let settingsUrl = Bundle.module.url(forResource: "settings", withExtension: "json")
             let settingsData = try Data(contentsOf: settingsUrl!)
@@ -67,6 +68,9 @@ internal class PassageSettings : PassageAuthSettings {
         } catch {
             version = "unknown"
         }
+        #else
+        self.version = "1.0.0"
+        #endif
     }
     
     


### PR DESCRIPTION
Cannot use Bundle.module in cocoapods, so wrap the access to settings.json with if swift_package and manually set version for non swift package manager.