### PR TITLE
Added OTP register, login, and activate methods.

### DIFF
--- a/Sources/Passage/AuthorizationController/PassageAutofillAuthorizationController.swift
+++ b/Sources/Passage/AuthorizationController/PassageAutofillAuthorizationController.swift
@@ -45,12 +45,13 @@ public class PassageAutofillAuthorizationController : NSObject, ASAuthorizationC
         }
     }
     
-    public func begin(onSuccess:  ((AuthResult) -> Void)?, onError: ((Error) -> Void)?, onCancel: (() -> Void)? ) async throws -> Void {
+    public func begin(anchor: ASPresentationAnchor, onSuccess:  ((AuthResult) -> Void)?, onError: ((Error) -> Void)?, onCancel: (() -> Void)? ) async throws -> Void {
      
         self.onSuccess = onSuccess
         self.onError = onError
         self.onCancel = onCancel
         
+        self.authenticationAnchor = anchor
         self.startResponse = try await PassageAuth.autoFillStart()
         
         let publicKeyCredentialProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: PassageSettings.shared.authOrigin!)

--- a/Sources/Passage/PassageAPIClient/PassageAPIClientModels.swift
+++ b/Sources/Passage/PassageAPIClient/PassageAPIClientModels.swift
@@ -1,18 +1,9 @@
-//
-//  PassageAPIClientModels.swift
-//  Shiny
-//
-//  Created by blayne bayer on 8/23/22.
-//  Copyright © 2022 Apple. All rights reserved.
-//
-
 /// A respsonse struct for the app info request, contains a root object of type ``AppInfo``
 internal struct AppInfoResponse : Codable {
     
     /// Root element of the response of type ``AppInfo``
     public var app: AppInfo
 }
-
 
 /// Details of the Public Key
 internal struct WebauthnLoginStartResponseHandshakeChallengePublicKey : Codable {
@@ -129,11 +120,13 @@ internal struct ActivateMagicLinkResponse : Codable {
     public var auth_result: AuthResult
 }
 
+internal struct ActivateOneTimePasscodeResponse : Codable {
+    public var auth_result: AuthResult
+}
 
 internal struct CurrentUserResponse : Codable {
     public var user: PassageUserDetails
 }
-
 
 internal struct ListDevicesResponse : Codable {
     public var devices: [DeviceInfo]
@@ -158,5 +151,3 @@ internal struct GetUserResponse : Codable {
 internal struct RefreshResponse : Codable {
     public var auth_result: AuthResult
 }
-
-

--- a/Sources/Passage/PassageAPIClient/PassageAPIClientProtocol.swift
+++ b/Sources/Passage/PassageAPIClient/PassageAPIClientProtocol.swift
@@ -1,12 +1,3 @@
-//
-//  PassageAPIClientProtocol.swift
-//  Shiny
-//
-//  Created by blayne bayer on 8/23/22.
-//  Copyright © 2022 Apple. All rights reserved.
-//
-
-import Foundation
 import AuthenticationServices
 
 /// Protocol that any Passage API Client must implement
@@ -123,6 +114,30 @@ protocol PassageAuthAPIClient  {
     func activateMagicLink(magicLink: String) async throws -> AuthResult
     
     
+    /// Send a new login one time passcode to the user's email or phone
+    /// - Parameters:
+    ///   - identifier: The users email or phone number
+    ///   - language: optional language string for localizing emails, if no lanuage or an invalid language is provided the application default lanuage will be used
+    /// - Returns: ``OneTimePasscode``
+    func sendLoginOneTimePasscode(identifier: String, language: String?) async throws -> OneTimePasscode
+    
+    
+    /// Send a new registration one time passcode to the user's email or phone
+    /// - Parameters:
+    ///   - identifier: The users email or phone number
+    ///   - language: optional language string for localizing emails, if no lanuage or an invalid language is provided the application default lanuage will be used
+    /// - Returns: ``OneTimePasscode``
+    func sendRegisterOneTimePasscode(identifier: String, language: String?) async throws -> OneTimePasscode
+    
+    
+    /// Active a magic link
+    /// - Parameters:
+    ///   - otp: The one time passcode to activate
+    ///   - otpId: The one time passcode id
+    /// - Returns: ``AuthResult``
+    func activateOneTimePasscode(otp: String, otpId: String) async throws -> AuthResult
+    
+    
     /// Get the detail for the current user
     /// - Parameter token: The user's access token
     /// - Returns: ``PassageUserDetails``
@@ -191,5 +206,3 @@ protocol PassageAuthAPIClient  {
     /// - Throws: ``PassageAPIError``
     func signOut(refreshToken: String) async throws
 }
-
-

--- a/Sources/Passage/PassageAuth.swift
+++ b/Sources/Passage/PassageAuth.swift
@@ -78,7 +78,7 @@ public class PassageAuth {
     ///   - onCancel: function to run if the user cancels the Passkey login
     /// - Returns: Void
     @available(iOS 16.0, *)
-    public func beginAutoFill(onSuccess:  ((AuthResult) -> Void)?, onError: ((Error) -> Void)?, onCancel: (() -> Void)?) async throws -> Void {
+    public func beginAutoFill(anchor: ASPresentationAnchor, onSuccess:  ((AuthResult) -> Void)?, onError: ((Error) -> Void)?, onCancel: (() -> Void)?) async throws -> Void {
         self.clearTokens()
 
         func onAutofillSuccess(authResult: AuthResult) -> Void {
@@ -89,7 +89,7 @@ public class PassageAuth {
             }
 
         }
-        try await PassageAutofillAuthorizationController.shared.begin(onSuccess: onAutofillSuccess, onError: onError, onCancel: onCancel)
+        try await PassageAutofillAuthorizationController.shared.begin(anchor: anchor, onSuccess: onAutofillSuccess, onError: onError, onCancel: onCancel)
 
     }
     
@@ -1184,8 +1184,8 @@ public class PassageAuth {
     ///   - onCancel: function to run if the user cancels the Passkey login
     /// - Returns: Void
     @available(iOS 16.0, *)
-    public static func beginAutoFill(onSuccess:  ((AuthResult) -> Void)?, onError: ((Error) -> Void)?, onCancel: (() -> Void)?) async throws -> Void {
-        try await PassageAutofillAuthorizationController.shared.begin(onSuccess: onSuccess, onError: onError, onCancel: onCancel)
+    public static func beginAutoFill(anchor: ASPresentationAnchor, onSuccess:  ((AuthResult) -> Void)?, onError: ((Error) -> Void)?, onCancel: (() -> Void)?) async throws -> Void {
+        try await PassageAutofillAuthorizationController.shared.begin(anchor: anchor, onSuccess: onSuccess, onError: onError, onCancel: onCancel)
     }
 
 }

--- a/Sources/Passage/PassageAuth.swift
+++ b/Sources/Passage/PassageAuth.swift
@@ -1,11 +1,3 @@
-//
-//  self.swift
-//  Shiny
-//
-//  Created by blayne bayer on 8/9/22.
-//  Copyright © 2022 Apple. All rights reserved.
-//
-
 import AuthenticationServices
 import os
 
@@ -628,7 +620,6 @@ public class PassageAuth {
             throw PassageError.unknown
         }
     }
-        
     
     /// Sign out the current user's session
     ///
@@ -795,6 +786,65 @@ public class PassageAuth {
             throw PassageError.unknown
         }
     }
+    
+    /// Creates and sends a one time passcode to the user. The user will receive an email or text to complete the registration.
+    ///
+    /// - Parameters:
+    ///   - identifier: string - email or phone number, depending on your app settings
+    ///   - language: optional language string for localizing emails, if no lanuage or an invalid language is provided the application default lanuage will be used
+    /// - Returns: ``OneTimePasscode``
+    /// - Throws: ``PassageAPIError``, ``PassageError``
+    public static func newRegisterOneTimePasscode(identifier: String, language: String? = nil) async throws -> OneTimePasscode {
+        do {
+            let oneTimePasscode = try await PassageAPIClient.shared.sendRegisterOneTimePasscode(identifier: identifier, language: language)
+            return oneTimePasscode
+        } catch {
+            if let error = error as? PassageAPIError {
+                try PassageAuth.handlePassageAPIError(error: error)
+            }
+            throw error
+        }
+    }
+    
+    /// Creates and sends a one time passcode to login the user. The user will receive an email or text to complete the login.
+    /// - Parameters:
+    ///   - identifier: string - email or phone number, depending on your app settings
+    ///   - language: optional language string for localizing emails, if no lanuage or an invalid language is provided the application default lanuage will be used
+    /// - Returns: ``OneTimePasscode``
+    /// - Throws: ``PassageAPIError``, ``PassageError``
+    public static func newLoginOneTimePasscode(identifier: String, language: String? = nil) async throws -> OneTimePasscode {
+        do {
+            let oneTimePasscode = try await PassageAPIClient.shared.sendLoginOneTimePasscode(identifier: identifier, language: language)
+            return oneTimePasscode
+        } catch {
+            if let error = error as? PassageAPIError {
+                try PassageAuth.handlePassageAPIError(error: error)
+            }
+            throw error
+        }
+    }
+    
+    /// Completes a one time passcode login workflow by activating the one time passcode.
+    ///
+    /// Used to activate either a login or registration one time passcode.
+    ///
+    /// - Parameters:
+    ///   - otp: The user's one time passcode
+    ///   - otpId: The one time passcode id
+    /// - Returns: ``AuthResult`` The AuthResult object contains an authentication token (JWT) and redirect URL. The auth token should be used on all subsequent authenticated requests to the app. The redirect URL specifies the route that users should be redirected to after completed registration or login
+    /// - Throws: ``PassageAPIError``, ``PassageError``
+    public static func oneTimePasscodeActivate(otp: String, otpId: String) async throws -> AuthResult {
+        do {
+            let authResult = try await PassageAPIClient.shared.activateOneTimePasscode(otp: otp, otpId: otpId)
+            return authResult
+        } catch {
+            if let error = error as? PassageAPIError {
+                try PassageAuth.handlePassageAPIError(error: error)
+            }
+            throw error
+        }
+    }
+    
            
     /// This method fetches the user by the specified token.
     /// - Parameter token: an auth token from the AuthResult object

--- a/Sources/Passage/PassageModels.swift
+++ b/Sources/Passage/PassageModels.swift
@@ -1,10 +1,3 @@
-//
-//  File.swift
-//  
-//
-//  Created by blayne bayer on 8/31/22.
-//
-
 import Foundation
 
 /// The authentication result containing the users tokens and redirect url
@@ -148,6 +141,15 @@ public struct AppInfo : Codable, Equatable {
 public struct MagicLink : Codable {
     /// id of the magic link
     public var id: String
+}
+
+/// Describes a one time passcode
+public struct OneTimePasscode : Codable {
+    /// id of the one time passcode
+    public let id: String
+    enum CodingKeys: String, CodingKey {
+        case id = "otp_id"
+    }
 }
 
 /// Information about a registered device

--- a/Tests/PassageTests/MockPassageAPIClient.swift
+++ b/Tests/PassageTests/MockPassageAPIClient.swift
@@ -75,6 +75,24 @@ final class MockPassageAPIClient: PassageAuthAPIClient {
         throw PassageError.unknown
     }
     
+    func sendLoginOneTimePasscode(identifier: String, language: String?) async throws -> Passage.OneTimePasscode {
+        guard identifier == "registered-test-user@passage.id" else {
+            throw PassageError.unknown
+        }
+        return Passage.OneTimePasscode(id: "TEST_ONE_TIME_PASSCODE")
+    }
+    
+    func sendRegisterOneTimePasscode(identifier: String, language: String?) async throws -> Passage.OneTimePasscode {
+        guard identifier == "unregistered-test-user@passage.id" else {
+            throw PassageError.userAlreadyExists
+        }
+        return Passage.OneTimePasscode(id: "TEST_ONE_TIME_PASSCODE")
+    }
+    
+    func activateOneTimePasscode(otp: String, otpId: String) async throws -> Passage.AuthResult {
+        throw PassageError.unknown
+    }
+    
     func currentUser(token: String) async throws -> Passage.PassageUserDetails {
         throw PassageError.unknown
     }


### PR DESCRIPTION
This PR:
* Replaces the autofill presentation anchor in `PassageAutofillAuthorizationController` (apps crash without it)
* Adds OTP register, login, and activate methods to `PassageAPIClient`
* Adds OTP register, login, and activate methods to `PassageAuth` 