### PR TITLE
Handle multiple fallbacks

### DIFF
--- a/Sources/Passage/PassageAPIClient/PassageAPIClient.swift
+++ b/Sources/Passage/PassageAPIClient/PassageAPIClient.swift
@@ -474,7 +474,7 @@ internal class PassageAPIClient : PassageAuthAPIClient {
     /// - Returns: ``AuthResult``
     /// - Throws: ``PassageAPIError``
     func activateOneTimePasscode(otp: String, otpId: String) async throws -> AuthResult {
-        let url = try appUrl(path: "otp/activate/")
+        let url = try appUrl(path: "otp/activate")
         
         let request = buildRequest(url: url, method: "POST")
         

--- a/Sources/Passage/PassageAPIClient/PassageAPIClient.swift
+++ b/Sources/Passage/PassageAPIClient/PassageAPIClient.swift
@@ -432,7 +432,7 @@ internal class PassageAPIClient : PassageAuthAPIClient {
                 
         let (responseData, response) = try await URLSession.shared.upload(for: request, from: data)
 
-        try assertValidResponse(response: response, responseData: responseData)
+        try assertValidResponse(response: response, responseData: responseData, successStatusCode: 201)
         
         let oneTimePasscode = try JSONDecoder().decode(OneTimePasscode.self, from: responseData)
         

--- a/Sources/Passage/PassageAPIClient/PassageAPIClient.swift
+++ b/Sources/Passage/PassageAPIClient/PassageAPIClient.swift
@@ -419,7 +419,7 @@ internal class PassageAPIClient : PassageAuthAPIClient {
     /// - Returns: ``OneTimePasscode``
     /// - Throws: ``PassageAPIError``
     func sendLoginOneTimePasscode(identifier: String, language: String?) async throws -> OneTimePasscode {
-        let url = try appUrl(path: "login/otp/")
+        let url = try appUrl(path: "login/otp")
         let request = buildRequest(url: url, method: "POST")
         
         var jsonObject = ["identifier": identifier]
@@ -446,7 +446,7 @@ internal class PassageAPIClient : PassageAuthAPIClient {
     /// - Returns: ``OneTimePasscode``
     /// - Throws: ``PassageAPIError``
     func sendRegisterOneTimePasscode(identifier: String, language: String?) async throws -> OneTimePasscode {
-        let url = try appUrl(path: "register/otp/")
+        let url = try appUrl(path: "register/otp")
         
         let request = buildRequest(url: url, method: "POST")
         

--- a/Sources/Passage/PassageAuth.swift
+++ b/Sources/Passage/PassageAuth.swift
@@ -28,29 +28,29 @@ public class PassageAuth {
     // MARK: Instance Public Methods
     
 
-    /// Register a new user using Passkeys or a magic link and manage the tokens.
+    /// Register a new user using a Passkey or a fallback method, and manage the tokens.
     ///
-    /// If the user is authenticated and not sent a magic link, the tokens will be stored in the tokenStore
+    /// If the user is authenticated and not sent a magic link or one time passcode, the tokens will be stored in the tokenStore
     /// on the instance.
     ///
     /// Note: Passkey registration is only available for iOS 16+, earlier versions of iOS will send a
-    /// registration magic link.
+    /// registration magic link or one time passcode.
     ///
     /// If your Passage application is configured to not allow public signups this method will throw
     /// a ``PassageRegisterError``.publicRegistrationDisabled.
     ///
-    /// If your Passage application is configured to require identifier verification then Passkeys will not be used and a magic link will
-    /// be sent and the user will have to verify their identifier before being authenticated.
+    /// If your Passage application is configured to require identifier verification then Passkeys will not be used and a magic link
+    /// or a one time passcode will be sent and the user will have to verify their identifier before being authenticated.
     ///
-    /// Returns a tuple (authResult: ``AuthResult``?, magicLink: ``MagicLink``?)
+    /// Returns a tuple (authResult: ``AuthResult``?, authFallbackResult: ``AuthFallbackResult``?)
     ///
-    /// If an authResult is returned the user was registered and logged in.  If a magicLink is returned the user was sent a magic link, and if neither
-    /// are returned, then the user was not registered and a magic link was not set.
+    /// If an authResult is returned the user was registered and logged in. If an authFallbackResult is returned the user was sent a magic link
+    /// or one time passcode, and if neither are returned, then the user was not registered and no fallback method was used.
     ///
     /// - Parameters:
     ///   - identifier: string - email or phone number, depending on your app settings
-    /// - Returns:  (authResult: ``AuthResult``?, magicLink: ``MagicLink``?)
-    public func register(identifier: String) async throws -> (authResult: AuthResult?, magicLink: MagicLink?) {
+    /// - Returns:  (authResult: ``AuthResult``?, authFallbackResult: ``AuthFallbackResult``?)
+    public func register(identifier: String) async throws -> (authResult: AuthResult?, authFallbackResult: AuthFallbackResult?) {
         self.clearTokens()
         let result = try await PassageAuth.register(identifier: identifier)
         if let authResult = result.authResult {
@@ -408,74 +408,52 @@ public class PassageAuth {
     
     
     
-    // MARK: Type Public Methods
+    // MARK: - Type Public Methods
     
-    /// Register a new user using Passkeys or a magic link
+    /// Register a new user using a Passkey or a fallback method
     ///
     /// Note: Passkey registration is only available for iOS 16+, earlier versions of iOS will send a
-    /// registration magic link.
+    /// registration magic link or one time passcode.
     ///
     /// If your Passage application is configured to not allow public signups this method will throw
     /// a ``PassageRegisterError``.publicRegistrationDisabled.
     ///
-    /// If your Passage application is configured to require identifier verification then Passkeys will not be used and a magic link will
-    /// be sent and the user will have to verify their identifier before being authenticated.
+    /// If your Passage application is configured to require identifier verification then Passkeys will not be used and a magic link
+    /// or a one time passcode will be sent and the user will have to verify their identifier before being authenticated.
     ///
-    /// Returns a tuple (authResult: ``AuthResult``?, magicLink: ``MagicLink``?)
+    /// Returns a tuple (authResult: ``AuthResult``?, authFallbackResult: ``AuthFallbackResult``?)
     ///
-    /// If an authResult is returned the user was registered and logged in.  If a magicLink is returned the user was sent a magic link, and if neither
-    /// are returned, then the user was not registered and a magic link was not set.
+    /// If an authResult is returned the user was registered and logged in.  If an authFallbackResult is returned the user was sent a magic link
+    /// or one time passcode, and if neither are returned, then the user was not registered and no fallback method was used.
     ///
     /// - Parameters:
     ///   - identifier: string - email or phone number, depending on your app settings
     /// - Returns:  (authResult: ``AuthResult``?, magicLink: ``MagicLink``?)
     /// - Throws: ``PassageError``, ``PassageAPIError``
-    public static func register(identifier: String) async throws -> (authResult: AuthResult?, magicLink: MagicLink?) {
-        var authResult: AuthResult?
-        var magicLink: MagicLink?
-        var sendMagicLink = false
-        
-        let appInfo = try await PassageAuth.appInfo()
-        
-        guard let unwrappedAppInfo = appInfo else {
+    public static func register(identifier: String) async throws -> (authResult: AuthResult?, authFallbackResult: AuthFallbackResult?) {
+        guard let appInfo = try? await PassageAuth.appInfo() else {
             throw PassageError.invalidAppInfo
         }
-       
-        let publicSignup = unwrappedAppInfo.publicSignup
-        let requiredIdentifierVerification = unwrappedAppInfo.requireIdentifierVerification
-
-        if (!publicSignup) {
+        guard appInfo.publicSignup else {
             throw PassageRegisterError.publicRegistrationDisabled
         }
-        
-        if #available(iOS 16.0, *) {
-            
-            if (requiredIdentifierVerification) {
-                sendMagicLink = true
-            } else {
-                do {
-                    authResult = try await PassageAuth.registerWithPasskey(identifier: identifier)
-                    return (authResult: authResult, magicLink: magicLink)
-                } catch (let error as PassageAPIError) {
-                    try PassageAuth.handlePassageAPIError(error: error)
-                } catch {
-                    throw error
-                }
+        let useFallback = appInfo.requireIdentifierVerification
+        guard !useFallback, #available(iOS 16.0, *) else {
+            guard let fallbackMethod = appInfo.authFallbackMethod else {
+                throw PassageError.invalidAuthFallbackMethod
             }
-
-        } else {
-            sendMagicLink = true
+            var authFallbackResult: AuthFallbackResult? = nil
+            switch fallbackMethod {
+            case .magicLink:
+                authFallbackResult = try? await PassageAuth.newRegisterMagicLink(identifier: identifier)
+            case .oneTimePasscode:
+                authFallbackResult = try? await PassageAuth.newRegisterOneTimePasscode(identifier: identifier)
+            }
+            return (nil, authFallbackResult)
         }
-
-        if (sendMagicLink) {
-            magicLink = try await PassageAuth.newRegisterMagicLink(identifier: identifier)
-            return (authResult: authResult, magicLink: magicLink)
-        }
-        
-        return (authResult: authResult, magicLink: magicLink)
+        let authResult = try? await PassageAuth.registerWithPasskey(identifier: identifier)
+        return (authResult, nil)
     }
-    
-
     
     /// Login a user with either a Passkey or send a magic link.
     ///

--- a/Sources/Passage/PassageAuth.swift
+++ b/Sources/Passage/PassageAuth.swift
@@ -51,10 +51,10 @@ public class PassageAuth {
     ///   - identifier: string - email or phone number, depending on your app settings
     /// - Returns:  (authResult: ``AuthResult``?, authFallbackResult: ``AuthFallbackResult``?)
     public func register(identifier: String) async throws -> (authResult: AuthResult?, authFallbackResult: AuthFallbackResult?) {
-        self.clearTokens()
+        clearTokens()
         let result = try await PassageAuth.register(identifier: identifier)
         if let authResult = result.authResult {
-            self.setTokensFromAuthResult(authResult: authResult)
+            setTokensFromAuthResult(authResult: authResult)
         }
         return result
     }
@@ -85,12 +85,12 @@ public class PassageAuth {
 
     }
     
-    /// Login a user with either a Passkey or send a magic link.
+    /// Login a user with either a Passkey or use a fallback method.
     ///
-    /// If the user is authenticated and not sent a magic link, the tokens will be stored in the tokenStore
+    /// If the user is authenticated and not sent a magic link or one time passcode, the tokens will be stored in the tokenStore
     /// on the instance.
     ///
-    /// NOTE: Passkey login is only available for iOS 16+, earlier versions of iOS will send a magic link.
+    /// NOTE: Passkey login is only available for iOS 16+, earlier versions of iOS will send magic link or one time passcode.
     ///
     /// iOS 16+
     /// On iOS 16+ this method will prompt a user to login to your app using a Passkey. This function handles the
@@ -99,28 +99,24 @@ public class PassageAuth {
     /// If the user does not have a Passkey or they cancel the Passkey prompt and an identifer is passed in
     /// a magic link will be sent.
     ///
-    /// If no identifier is passed in, then this method will not attempt to send a magic link and simply return with nil for
-    /// both the authResult and magicLink props of the result.
-    ///
     /// iOS 14 and 15
     ///
-    /// This method will send a magic link to the user (either email or text depending on identifier).  If no identifier is
-    /// is passed in, this method will throw PassageLoginError.identifierRequired
+    /// This method will send a magic link or one time passcode to the user (either email or text depending on identifier).
     ///
-    /// Returns a tuple (authResult: ``AuthResult``?, magicLink: ``MagicLink``?)
+    /// Returns a tuple (authResult: ``AuthResult``?, authFallbackResult: ``AuthFallbackResult``?)
     ///
-    /// If an authResult is returned the user was logged in.  If a magicLink is returned the user was sent a magic link, and if neither
-    /// are returned, then the user was not logged in and a magic link was not set.
+    /// If an authResult is returned the user was logged in.  If an authFallbackResult is returned the user was sent a magic link or a one time passcode,
+    /// and if neither are returned, then the user was not logged in and no fallback method was used.
     ///
     /// - Parameters:
     ///   - identifier: string - email or phone number, depending on your app settings
-    /// - Returns:  (authResult: ``AuthResult``?, magicLink: ``MagicLink``?)
-    /// - Throws: ``PasageLoginError``, ``PassageAPIError``
-    public func login(identifier: String) async throws -> (authResult: AuthResult?, magicLink: MagicLink?) {
-        self.clearTokens()
+    /// - Returns:  (authResult: ``AuthResult``?, authFallbackResult: ``AuthFallbackResult``?)
+    /// - Throws: ``PasageLoginError``, ``PassageAPIError``, ``PassageError``
+    public func login(identifier: String) async throws -> (authResult: AuthResult?, authFallbackResult: AuthFallbackResult?) {
+        clearTokens()
         let result = try await PassageAuth.login(identifier: identifier)
         if let authResult = result.authResult {
-            self.setTokensFromAuthResult(authResult: authResult)
+            setTokensFromAuthResult(authResult: authResult)
         }
         return result
     }
@@ -448,6 +444,8 @@ public class PassageAuth {
                 authFallbackResult = try? await PassageAuth.newRegisterMagicLink(identifier: identifier)
             case .oneTimePasscode:
                 authFallbackResult = try? await PassageAuth.newRegisterOneTimePasscode(identifier: identifier)
+            case .none:
+                throw PassageError.authFallbacksNotSupported
             }
             return (nil, authFallbackResult)
         }
@@ -455,9 +453,9 @@ public class PassageAuth {
         return (authResult, nil)
     }
     
-    /// Login a user with either a Passkey or send a magic link.
+    /// Login a user with either a Passkey or use a fallback method.
     ///
-    /// NOTE: Passkey login is only available for iOS 16+, earlier versions of iOS will send a magic link.
+    /// NOTE: Passkey login is only available for iOS 16+, earlier versions of iOS will send magic link or one time passcode.
     ///
     /// iOS 16+
     /// On iOS 16+ this method will prompt a user to login to your app using a Passkey. This function handles the
@@ -466,73 +464,42 @@ public class PassageAuth {
     /// If the user does not have a Passkey or they cancel the Passkey prompt and an identifer is passed in
     /// a magic link will be sent.
     ///
-    /// If no identifier is passed in, then this method will not attempt to send a magic link and simply return with nil for
-    /// both the authResult and magicLink props of the result.
-    ///
     /// iOS 14 and 15
     ///
-    /// This method will send a magic link to the user (either email or text depending on identifier).  If no identifier is
-    /// is passed in, this method will throw PassageLoginError.identifierRequired
+    /// This method will send a magic link or one time passcode to the user (either email or text depending on identifier).
     ///
-    /// Returns a tuple (authResult: ``AuthResult``?, magicLink: ``MagicLink``?)
+    /// Returns a tuple (authResult: ``AuthResult``?, authFallbackResult: ``AuthFallbackResult``?)
     ///
-    /// If an authResult is returned the user was logged in.  If a magicLink is returned the user was sent a magic link, and if neither
-    /// are returned, then the user was not logged in and a magic link was not set.
+    /// If an authResult is returned the user was logged in.  If an authFallbackResult is returned the user was sent a magic link or a one time passcode,
+    /// and if neither are returned, then the user was not logged in and no fallback method was used.
     ///
     /// - Parameters:
     ///   - identifier: string - email or phone number, depending on your app settings
-    /// - Returns:  (authResult: ``AuthResult``?, magicLink: ``MagicLink``?)
+    /// - Returns:  (authResult: ``AuthResult``?, authFallbackResult: ``AuthFallbackResult``?)
     /// - Throws: ``PasageLoginError``, ``PassageAPIError``, ``PassageError``
-    public static func login(identifier: String) async throws -> (authResult: AuthResult?, magicLink: MagicLink?) {
-        
-        var authResult: AuthResult?
-        var magicLink: MagicLink?
-            
-        let identifierExists = try await PassageAuth.identifierExists(identifier: identifier)
-
-        guard identifierExists else {
+    public static func login(identifier: String) async throws  -> (authResult: AuthResult?, authFallbackResult: AuthFallbackResult?) {
+        guard (try? await PassageAuth.identifierExists(identifier: identifier)) == true else {
             throw PassageError.userDoesNotExist
         }
-        
-        // Try passkey login
-
-        if #available(iOS 16.0, *) {
-            do {
-                authResult = try await PassageAuth.loginWithPasskey()
-            }
-            catch (let error as PassageASAuthorizationError)  {
-                switch error {
-                case .canceled:
-                    authResult = nil
-                    break
-                default:
-                    throw error
-                }
-            } catch (let error as PassageAPIError) {
-                try PassageAuth.handlePassageAPIError(error: error)
-            } catch {
-                throw error
-            }
+        if #available(iOS 16.0, *), let authResult = try? await PassageAuth.loginWithPasskey() {
+            return (authResult, nil)
         }
-        
-        if (authResult == nil ) {
-            do {
-                magicLink = try await self.loginWithMagicLink(identifier: identifier)
-            } catch (let error as PassageAPIError) {
-                try PassageAuth.handlePassageAPIError(error: error)
-            } catch {
-                throw error
-            }
+        guard let appInfo = try? await PassageAuth.appInfo() else {
+            throw PassageError.invalidAppInfo
         }
-        
-
-        if (authResult == nil && magicLink == nil) {
-            throw PassageError.unknown
+        guard let fallbackMethod = appInfo.authFallbackMethod else {
+            throw PassageError.invalidAuthFallbackMethod
         }
-        
-        return (authResult: authResult, magicLink: magicLink)
-        
-
+        var authFallbackResult: AuthFallbackResult? = nil
+        switch fallbackMethod {
+        case .magicLink:
+            authFallbackResult = try? await newLoginMagicLink(identifier: identifier)
+        case .oneTimePasscode:
+            authFallbackResult = try? await newLoginOneTimePasscode(identifier: identifier)
+        case .none:
+            throw PassageError.authFallbacksNotSupported
+        }
+        return (nil, authFallbackResult)
     }
     
     

--- a/Sources/Passage/PassageAuth.swift
+++ b/Sources/Passage/PassageAuth.swift
@@ -441,8 +441,8 @@ public class PassageAuth {
             throw PassageError.invalidAppInfo
         }
        
-        let publicSignup = unwrappedAppInfo.public_signup
-        let requiredIdentifierVerification = unwrappedAppInfo.require_identifier_verification
+        let publicSignup = unwrappedAppInfo.publicSignup
+        let requiredIdentifierVerification = unwrappedAppInfo.requireIdentifierVerification
 
         if (!publicSignup) {
             throw PassageRegisterError.publicRegistrationDisabled

--- a/Sources/Passage/PassageAuth.swift
+++ b/Sources/Passage/PassageAuth.swift
@@ -441,9 +441,9 @@ public class PassageAuth {
             var authFallbackResult: AuthFallbackResult? = nil
             switch fallbackMethod {
             case .magicLink:
-                authFallbackResult = try? await PassageAuth.newRegisterMagicLink(identifier: identifier)
+                authFallbackResult = try await PassageAuth.newRegisterMagicLink(identifier: identifier)
             case .oneTimePasscode:
-                authFallbackResult = try? await PassageAuth.newRegisterOneTimePasscode(identifier: identifier)
+                authFallbackResult = try await PassageAuth.newRegisterOneTimePasscode(identifier: identifier)
             case .none:
                 throw PassageError.authFallbacksNotSupported
             }
@@ -493,9 +493,9 @@ public class PassageAuth {
         var authFallbackResult: AuthFallbackResult? = nil
         switch fallbackMethod {
         case .magicLink:
-            authFallbackResult = try? await newLoginMagicLink(identifier: identifier)
+            authFallbackResult = try await newLoginMagicLink(identifier: identifier)
         case .oneTimePasscode:
-            authFallbackResult = try? await newLoginOneTimePasscode(identifier: identifier)
+            authFallbackResult = try await newLoginOneTimePasscode(identifier: identifier)
         case .none:
             throw PassageError.authFallbacksNotSupported
         }

--- a/Sources/Passage/PassageErrors.swift
+++ b/Sources/Passage/PassageErrors.swift
@@ -30,6 +30,7 @@ public enum PassageError: Error, Equatable {
     case userDoesNotExist
     case invalidAppInfo
     case invalidAuthFallbackMethod
+    case authFallbacksNotSupported
 }
 
 /// Passage Device Errors

--- a/Sources/Passage/PassageErrors.swift
+++ b/Sources/Passage/PassageErrors.swift
@@ -1,16 +1,7 @@
-//
-//  PassageErrors.swift
-//  Shiny
-//
-//  Created by Ricky C Padilla on 8/8/22.
-//  Copyright © 2022 Apple. All rights reserved.
-//
-
 import Foundation
 
-
 /// Errors thrown from the ASAuthorization Controller
-public enum PassageASAuthorizationError : Error {
+public enum PassageASAuthorizationError: Error {
     case authorizationTypeUnknown
     case canceled
     case credentialRegistration
@@ -38,10 +29,11 @@ public enum PassageError: Error, Equatable {
     case userAlreadyExists
     case userDoesNotExist
     case invalidAppInfo
+    case invalidAuthFallbackMethod
 }
 
 /// Passage Device Errors
-public enum PassageDeviceError : Error {
+public enum PassageDeviceError: Error {
     case notFound
 }
 

--- a/Sources/Passage/PassageModels.swift
+++ b/Sources/Passage/PassageModels.swift
@@ -111,7 +111,7 @@ public struct AppInfo: Codable, Equatable {
     /// How long is the auth token valid
     public let sessionTimeoutLength: Int
 
-    enum CodingKeys: String, CodingKey {
+    internal enum CodingKeys: String, CodingKey {
         case allowedIdentifier = "allowed_identifier"
         case authFallbackMethodString = "auth_fallback_method"
         case authOrigin = "auth_origin"
@@ -130,6 +130,7 @@ public struct AppInfo: Codable, Equatable {
     public enum AuthFallbackMethod: String {
         case magicLink = "magic_link"
         case oneTimePasscode = "otp"
+        case none = "none"
     }
     
     /// Which fallback method is set in the Passage Application when Passkeys are not available

--- a/Sources/Passage/PassageModels.swift
+++ b/Sources/Passage/PassageModels.swift
@@ -139,17 +139,20 @@ public struct AppInfo: Codable, Equatable {
     
 }
 
+public protocol AuthFallbackResult: Codable {
+    var id: String { get set }
+}
 
 /// Describes a magic link
-public struct MagicLink : Codable {
+public struct MagicLink: AuthFallbackResult {
     /// id of the magic link
     public var id: String
 }
 
 /// Describes a one time passcode
-public struct OneTimePasscode: Codable {
+public struct OneTimePasscode: AuthFallbackResult {
     /// id of the one time passcode
-    public let id: String
+    public var id: String
     enum CodingKeys: String, CodingKey {
         case id = "otp_id"
     }

--- a/Sources/Passage/PassageModels.swift
+++ b/Sources/Passage/PassageModels.swift
@@ -83,57 +83,60 @@ public struct WebauthnDevice : Codable {
 }
 
 /// Struct describing a Passage Application
-public struct AppInfo : Codable, Equatable {
-    
-    /// The id of the Passage Application
-    public var id: String
-    
-    
-    /// If this is an ephemeral app
-    public var ephemeral: Bool
-    
-    
-    /// The name of the Passage Application
-    public var name: String
-    
-    
-    /// The Pasage Application redirect url
-    public var redirect_url: String
-    
-    
-    /// The Login URL of the Passage Application
-    public var login_url: String
-    
-    
+public struct AppInfo: Codable, Equatable {
     /// Allowed identifier (email or phone)
-    public var allowed_identifier: String
-    
-    /// The identifier type that is required
-    public var required_identifier: String
-    
-    
+    public let allowedIdentifier: String
+    /// String representation of which fallback method is set in the Passage Application when Passkeys are not available
+    internal let authFallbackMethodString: String
     /// The Passage Applications auth origin
-    public var auth_origin: String
-    
-    
-    /// Whether the Passage Application requires email verificiation
-    public var require_email_verification: Bool
-    
-    
-    /// Whether the Passage Application required identifier verification when registering
-    public var require_identifier_verification: Bool
-    
-    
-    /// How long is the auth token valid
-    public var session_timeout_length: Int
-
-    //    var user_metadata_schema: [String: String]
-
-    //    var layouts: [String: String]
-    
-    
+    public let authOrigin: String
+    /// If this is an ephemeral app
+    public let ephemeral: Bool
+    /// The id of the Passage Application
+    public let id: String
+    /// The Login URL of the Passage Application
+    public let loginURL: String
+    /// The name of the Passage Application
+    public let name: String
     /// Allow public signup
-    public var public_signup: Bool
+    public let publicSignup: Bool
+    /// The Pasage Application redirect url
+    public let redirectURL: String
+    /// The identifier type that is required
+    public let requiredIdentifier: String
+    /// Whether the Passage Application requires email verificiation
+    public let requireEmailVerification: Bool
+    /// Whether the Passage Application required identifier verification when registering
+    public let requireIdentifierVerification: Bool
+    /// How long is the auth token valid
+    public let sessionTimeoutLength: Int
+
+    enum CodingKeys: String, CodingKey {
+        case allowedIdentifier = "allowed_identifier"
+        case authFallbackMethodString = "auth_fallback_method"
+        case authOrigin = "auth_origin"
+        case ephemeral
+        case id
+        case loginURL = "login_url"
+        case name
+        case publicSignup = "public_signup"
+        case redirectURL = "redirect_url"
+        case requiredIdentifier = "required_identifier"
+        case requireEmailVerification = "require_email_verification"
+        case requireIdentifierVerification = "require_identifier_verification"
+        case sessionTimeoutLength = "session_timeout_length"
+    }
+    
+    public enum AuthFallbackMethod: String {
+        case magicLink = "magic_link"
+        case oneTimePasscode = "otp"
+    }
+    
+    /// Which fallback method is set in the Passage Application when Passkeys are not available
+    public var authFallbackMethod: AuthFallbackMethod? {
+        return AuthFallbackMethod(rawValue: authFallbackMethodString)
+    }
+    
 }
 
 
@@ -144,7 +147,7 @@ public struct MagicLink : Codable {
 }
 
 /// Describes a one time passcode
-public struct OneTimePasscode : Codable {
+public struct OneTimePasscode: Codable {
     /// id of the one time passcode
     public let id: String
     enum CodingKeys: String, CodingKey {

--- a/Tests/Integration/IntegrationTestData.swift
+++ b/Tests/Integration/IntegrationTestData.swift
@@ -46,64 +46,65 @@ let currentUser = PassageUserDetails(
 
 
 let appInfoValid = AppInfo(
-    id: "czLTOVFIytGqrhRVoHV9o8Wo",
+    allowedIdentifier: "both",
+    authFallbackMethodString: "magic_link",
+    authOrigin: "http://localhost:4173",
     ephemeral: false,
+    id: "czLTOVFIytGqrhRVoHV9o8Wo",
+    loginURL: "/",
     name: "passage-ios uat",
-    redirect_url: "/dashboard",
-    login_url: "/",
-    allowed_identifier: "both",
-    required_identifier: "both",
-    auth_origin: "http://localhost:4173",
-    require_email_verification: false,
-    require_identifier_verification: false,
-    session_timeout_length: 0,
-    public_signup: true
+    publicSignup: true,
+    redirectURL: "/dashboard",
+    requiredIdentifier: "both",
+    requireEmailVerification: false,
+    requireIdentifierVerification: false,
+    sessionTimeoutLength: 0
 )
 
 let appInfoInvalid = AppInfo(
-    id: "TEST_APP_ID",
+    allowedIdentifier: "TEST_ALLOWED_IDENTIFIER",
+    authFallbackMethodString: "magic_link",
+    authOrigin: "TEST_AUTH_ORIGIN",
     ephemeral: true,
+    id: "TEST_APP_ID",
+    loginURL: "TEST_LOGIN_URL",
     name: "TEST_APP",
-    redirect_url: "TEST_APP_URL",
-    login_url: "TEST_LOGIN_URL",
-    allowed_identifier: "TEST_ALLOWED_IDENTIFIER",
-    required_identifier: "TEST_REQUIRED_IDENTIFIER",
-    auth_origin: "TEST_AUTH_ORIGIN",
-    require_email_verification: false,
-    require_identifier_verification: false,
-    session_timeout_length: 6000,
-    public_signup: true
+    publicSignup: true,
+    redirectURL: "TEST_APP_URL",
+    requiredIdentifier: "TEST_REQUIRED_IDENTIFIER",
+    requireEmailVerification: false,
+    requireIdentifierVerification: false,
+    sessionTimeoutLength: 6000
 )
 
 let appInfoRefreshToken = AppInfo(
-    id: "uFZlFit7nglPuzcYRVesCUBZ",
+    allowedIdentifier: "both",
+    authFallbackMethodString: "magic_link",
+    authOrigin: "http://localhost:4173",
     ephemeral: false,
+    id: "uFZlFit7nglPuzcYRVesCUBZ",
+    loginURL: "/",
     name: "passage-ios uat refresh tokens",
-    redirect_url: "/dashboard",
-    login_url: "/",
-    allowed_identifier: "both",
-    required_identifier: "both",
-    auth_origin: "http://localhost:4173",
-    require_email_verification: false,
-    require_identifier_verification: false,
-    session_timeout_length: 5,
-    public_signup: true
+    publicSignup: true,
+    redirectURL: "/dashboard",
+    requiredIdentifier: "both",
+    requireEmailVerification: false,
+    requireIdentifierVerification: false,
+    sessionTimeoutLength: 5
 )
 
-
-
-
 let appInfoTest = AppInfo(
-    id: "TEST_APP_ID",
+    allowedIdentifier: "TEST_ALLOWED_IDENTIFIER",
+    authFallbackMethodString: "magic_link",
+    authOrigin: "TEST_AUTH_ORIGIN",
     ephemeral: true,
+    id: "TEST_APP_ID",
+    loginURL: "TEST_LOGIN_URL",
     name: "TEST_APP",
-    redirect_url: "TEST_APP_URL",
-    login_url: "TEST_LOGIN_URL",
-    allowed_identifier: "TEST_ALLOWED_IDENTIFIER",
-    required_identifier: "TEST_REQUIRED_IDENTIFIER",
-    auth_origin: "TEST_AUTH_ORIGIN",
-    require_email_verification: false,
-    require_identifier_verification: false,
-    session_timeout_length: 6000,
-    public_signup: true
+    publicSignup: true,
+    redirectURL: "TEST_APP_URL",
+    requiredIdentifier: "TEST_REQUIRED_IDENTIFIER",
+    requireEmailVerification: false,
+    requireIdentifierVerification: false,
+    sessionTimeoutLength: 6000
 )

--- a/Tests/PassageTests/PassageAuthStaticTestData.swift
+++ b/Tests/PassageTests/PassageAuthStaticTestData.swift
@@ -5,18 +5,19 @@ let unregisteredUserEmail = "unregistered-test-user@passage.id"
 let registeredUserEmail = "registered-test-user@passage.id"
 
 let testAppInfo = AppInfo(
-    id: "TEST_APP_ID",
+    allowedIdentifier: "TEST_ALLOWED_IDENTIFIER",
+    authFallbackMethodString: "magic_link",
+    authOrigin: "TEST_AUTH_ORIGIN",
     ephemeral: true,
+    id: "TEST_APP_ID",
+    loginURL: "TEST_LOGIN_URL",
     name: "TEST_APP",
-    redirect_url: "TEST_APP_URL",
-    login_url: "TEST_LOGIN_URL",
-    allowed_identifier: "TEST_ALLOWED_IDENTIFIER",
-    required_identifier: "TEST_REQUIRED_IDENTIFIER",
-    auth_origin: "TEST_AUTH_ORIGIN",
-    require_email_verification: false,
-    require_identifier_verification: false,
-    session_timeout_length: 6000,
-    public_signup: true
+    publicSignup: true,
+    redirectURL: "TEST_APP_URL",
+    requiredIdentifier: "TEST_REQUIRED_IDENTIFIER",
+    requireEmailVerification: false,
+    requireIdentifierVerification: false,
+    sessionTimeoutLength: 6000
 )
 
 let testLoginStartResponse = WebauthnLoginStartResponse(

--- a/Tests/PassageTests/PassageAuthStaticTests.swift
+++ b/Tests/PassageTests/PassageAuthStaticTests.swift
@@ -6,7 +6,7 @@ final class PassageAuthStaticTests: XCTestCase {
     override func setUp() {
         super.setUp()
         PassageSettings.shared.appId = testAppInfo.id
-        PassageSettings.shared.authOrigin = testAppInfo.auth_origin
+        PassageSettings.shared.authOrigin = testAppInfo.authOrigin
         PassageSettings.shared.apiUrl = "TEST_API_URL"
         PassageAPIClient.shared = MockPassageAPIClient()
         if #available(iOS 16.0, *) {

--- a/Tests/PassageTests/PassageAuthStaticTests.swift
+++ b/Tests/PassageTests/PassageAuthStaticTests.swift
@@ -53,7 +53,7 @@ final class PassageAuthStaticTests: XCTestCase {
         if #available(iOS 16.0, *) {
             XCTAssertTrue(result?.authResult is AuthResult)
         } else {
-            XCTAssertTrue(result?.magicLink is MagicLink)
+            XCTAssertTrue(result?.authFallbackResult is AuthFallbackResult)
         }
     }
     

--- a/Tests/PassageTests/PassageAuthStaticTests.swift
+++ b/Tests/PassageTests/PassageAuthStaticTests.swift
@@ -44,7 +44,7 @@ final class PassageAuthStaticTests: XCTestCase {
         if #available(iOS 16.0, *) {
             XCTAssertTrue(result?.authResult is AuthResult)
         } else {
-            XCTAssertTrue(result?.magicLink is MagicLink)
+            XCTAssertTrue(result?.authFallbackResult is AuthFallbackResult)
         }
     }
     


### PR DESCRIPTION
The Passage iOS SDK previously only used magic links for fallbacks. This PR modifies the registration and login methods to fallback to what the Passage Admin has set in the Passage Console, including one time passcodes or no fallback at all.

Below is an example implementation of the updated `PassageAuth.register` and a demo where the Passage Admin has set the fallback to be one time passcodes.

This PR also includes some minor code cleanup.

<img width="1627" alt="Screenshot 2023-04-11 at 3 21 09 PM" src="https://user-images.githubusercontent.com/16176400/231291133-4c0f0c9f-f4b4-44da-81c6-f7ac613dcf19.png">


https://user-images.githubusercontent.com/16176400/231291158-a7723bcf-b345-422b-89df-860637df5d8d.mov

