### PR TITLE
One Time Passcode support

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,5 @@
 
-Copyright (c) 2022 Passage Identity, Inc. <hello@passage.id> (https://passage.id)
+Copyright (c) 2023 Passage Identity, Inc. <hello@passage.id> (https://passage.id)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Passage.podspec
+++ b/Passage.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = 'Passage'
-    s.version          = ENV['LIB_VERSION'] || '0.2.0' #fallback to major version
+    s.version          = ENV['LIB_VERSION'] || '1.1.0' #fallback to major version
     s.summary          = 'Use Passage Authentication in your iOS application'
     s.homepage         = 'https://github.com/passageidentity/passage-ios'
     s.license          = { :type => 'MIT', :file => 'LICENSE.md' }

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Compatile with [Xcode](https://developer.apple.com/xcode/) version 14+.
 
 The Passage-iOS SDK is supported for iOS version 14+. However, Passkeys are only supported on iOS v16+.
 
-| iOS Version 	| Passkey Login 	 | Magic Link Login 	|
+| iOS Version 	| Passkey Login 	 | Passcode & Magic Link Login 	|
 |-------------	|      :----:      |        :----: 	    |
 | v16.x       	|       ✅       	|           ✅        |
 | v15.x     	|        ❌       	|           ✅      	 |
@@ -63,7 +63,7 @@ https://github.com/passageidentity/passage-ios
 Add the following line to your Podfile:
 
 ```
-pod 'Passage', '~> 0.1'
+pod 'Passage', '~> 1.1'
 ```
 Then, run pod install.
 
@@ -71,8 +71,7 @@ For further reference on Cocoapods, check their [official documentation](https:/
 
 
 - Run `pod install`
-  <br>
-  NOTE: This is NOT yet working in Xcode 14 beta on M1 Macs.
+
 
 # Setup Guide
 

--- a/Sources/Passage/AuthorizationController/PassageAutofillAuthorizationController.swift
+++ b/Sources/Passage/AuthorizationController/PassageAutofillAuthorizationController.swift
@@ -78,7 +78,7 @@ public class PassageAutofillAuthorizationController : NSObject, ASAuthorizationC
                     throw PassageASAuthorizationError.invalidStartResponse
                 }
                 let loginResult = try await PassageAuth.autoFillFinish(startResponse: self.startResponse!, credentialAssertion: credentialAssertion)
-                if (loginResult.auth_token != nil) {
+                if (loginResult.authToken != nil) {
                     self.isPerformingModalRequest = false
                     if let onSuccess = self.onSuccess {
                         onSuccess(loginResult)

--- a/Sources/Passage/AuthorizationController/PassageAutofillAuthorizationController.swift
+++ b/Sources/Passage/AuthorizationController/PassageAutofillAuthorizationController.swift
@@ -45,12 +45,13 @@ public class PassageAutofillAuthorizationController : NSObject, ASAuthorizationC
         }
     }
     
-    public func begin(onSuccess:  ((AuthResult) -> Void)?, onError: ((Error) -> Void)?, onCancel: (() -> Void)? ) async throws -> Void {
+    public func begin(anchor: ASPresentationAnchor, onSuccess:  ((AuthResult) -> Void)?, onError: ((Error) -> Void)?, onCancel: (() -> Void)? ) async throws -> Void {
      
         self.onSuccess = onSuccess
         self.onError = onError
         self.onCancel = onCancel
         
+        self.authenticationAnchor = anchor
         self.startResponse = try await PassageAuth.autoFillStart()
         
         let publicKeyCredentialProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: PassageSettings.shared.authOrigin!)

--- a/Sources/Passage/AuthorizationController/PassageAutofillAuthorizationController.swift
+++ b/Sources/Passage/AuthorizationController/PassageAutofillAuthorizationController.swift
@@ -74,31 +74,22 @@ public class PassageAutofillAuthorizationController : NSObject, ASAuthorizationC
         switch authorization.credential {
         case let credentialAssertion as ASAuthorizationPlatformPublicKeyCredentialAssertion:
             Task {
-                guard self.startResponse != nil else {
+                guard startResponse != nil else {
                     throw PassageASAuthorizationError.invalidStartResponse
                 }
-                let loginResult = try await PassageAuth.autoFillFinish(startResponse: self.startResponse!, credentialAssertion: credentialAssertion)
-                if (loginResult.authToken != nil) {
-                    self.isPerformingModalRequest = false
-                    if let onSuccess = self.onSuccess {
-                        onSuccess(loginResult)
-                    }
-                } else {
-                    self.isPerformingModalRequest = false
-                    if let onError = self.onError {
-                        onError(PassageASAuthorizationError.loginFinish)
-                    }
-
+                let loginResult = try await PassageAuth.autoFillFinish(startResponse: startResponse!, credentialAssertion: credentialAssertion)
+                isPerformingModalRequest = false
+                if let onSuccess {
+                    onSuccess(loginResult)
                 }
             }
         default:
-            self.isPerformingModalRequest = false
-            if let onError = self.onError {
+            isPerformingModalRequest = false
+            if let onError = onError {
                 onError(PassageASAuthorizationError.authorizationTypeUnknown)
             }
         }
-        
-        self.isPerformingModalRequest = false
+        isPerformingModalRequest = false
     }
     
     public func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {

--- a/Sources/Passage/PassageAPIClient/PassageAPIClient.swift
+++ b/Sources/Passage/PassageAPIClient/PassageAPIClient.swift
@@ -419,7 +419,7 @@ internal class PassageAPIClient : PassageAuthAPIClient {
     /// - Returns: ``OneTimePasscode``
     /// - Throws: ``PassageAPIError``
     func sendLoginOneTimePasscode(identifier: String, language: String?) async throws -> OneTimePasscode {
-        let url = try appUrl(path: "login/otp/")
+        let url = try appUrl(path: "login/otp")
         let request = buildRequest(url: url, method: "POST")
         
         var jsonObject = ["identifier": identifier]
@@ -432,7 +432,7 @@ internal class PassageAPIClient : PassageAuthAPIClient {
                 
         let (responseData, response) = try await URLSession.shared.upload(for: request, from: data)
 
-        try assertValidResponse(response: response, responseData: responseData)
+        try assertValidResponse(response: response, responseData: responseData, successStatusCode: 201)
         
         let oneTimePasscode = try JSONDecoder().decode(OneTimePasscode.self, from: responseData)
         
@@ -446,7 +446,7 @@ internal class PassageAPIClient : PassageAuthAPIClient {
     /// - Returns: ``OneTimePasscode``
     /// - Throws: ``PassageAPIError``
     func sendRegisterOneTimePasscode(identifier: String, language: String?) async throws -> OneTimePasscode {
-        let url = try appUrl(path: "register/otp/")
+        let url = try appUrl(path: "register/otp")
         
         let request = buildRequest(url: url, method: "POST")
         
@@ -474,7 +474,7 @@ internal class PassageAPIClient : PassageAuthAPIClient {
     /// - Returns: ``AuthResult``
     /// - Throws: ``PassageAPIError``
     func activateOneTimePasscode(otp: String, otpId: String) async throws -> AuthResult {
-        let url = try appUrl(path: "otp/activate/")
+        let url = try appUrl(path: "otp/activate")
         
         let request = buildRequest(url: url, method: "POST")
         

--- a/Sources/Passage/PassageAPIClient/PassageAPIClient.swift
+++ b/Sources/Passage/PassageAPIClient/PassageAPIClient.swift
@@ -116,7 +116,7 @@ internal class PassageAPIClient : PassageAuthAPIClient {
         
         let authResponse = try JSONDecoder().decode(WebauthnLoginFinishResponse.self, from: responseData)
 
-        return authResponse.auth_result
+        return authResponse.authResult
     }
     
     /// Peform a webauthn login start request for the specified identifier
@@ -181,7 +181,7 @@ internal class PassageAPIClient : PassageAuthAPIClient {
         
         let authResponse = try JSONDecoder().decode(WebauthnLoginFinishResponse.self, from: responseData)
 
-        return authResponse.auth_result
+        return authResponse.authResult
         
     }
 
@@ -250,7 +250,7 @@ internal class PassageAPIClient : PassageAuthAPIClient {
 
         let authResponse = try JSONDecoder().decode(WebauthnRegisterFinishResponse.self, from: responseData)
 
-        return authResponse.auth_result
+        return authResponse.authResult
     }
     
     /// Peform a webauthn add device start request
@@ -339,7 +339,7 @@ internal class PassageAPIClient : PassageAuthAPIClient {
         
         let sendMagicLinkResponse = try JSONDecoder().decode(SendMagicLinkResponse.self, from: responseData)
         
-        return sendMagicLinkResponse.magic_link
+        return sendMagicLinkResponse.magicLink
     }
     
     /// Send a new registration magic link to the users email or phone
@@ -369,7 +369,7 @@ internal class PassageAPIClient : PassageAuthAPIClient {
         
         let sendMagicLinkResponse = try JSONDecoder().decode(SendMagicLinkResponse.self, from: responseData)
         
-        return sendMagicLinkResponse.magic_link
+        return sendMagicLinkResponse.magicLink
     }
     
     /// Check the status of a magic link
@@ -389,7 +389,7 @@ internal class PassageAPIClient : PassageAuthAPIClient {
         
         let magicLinkStatusResponse = try JSONDecoder().decode(MagicLinkStatusResponse.self, from: responseData)
         
-        return magicLinkStatusResponse.auth_result
+        return magicLinkStatusResponse.authResult
     }
     
     /// Active a magic link
@@ -409,7 +409,7 @@ internal class PassageAPIClient : PassageAuthAPIClient {
         
         let activateMagicLinkResponse = try JSONDecoder().decode(ActivateMagicLinkResponse.self, from: responseData)
         
-        return activateMagicLinkResponse.auth_result
+        return activateMagicLinkResponse.authResult
     }
     
     /// Send a new login one time passcode to the user's email or phone
@@ -486,14 +486,14 @@ internal class PassageAPIClient : PassageAuthAPIClient {
         
         let activateOneTimePasscodeResponse = try JSONDecoder().decode(ActivateOneTimePasscodeResponse.self, from: responseData)
         
-        return activateOneTimePasscodeResponse.auth_result
+        return activateOneTimePasscodeResponse.authResult
     }
     
     /// Get the detail for the current user
     /// - Parameter token: The user's access token
-    /// - Returns: ``PassageUserDetails``
+    /// - Returns: ``PassageUserInfo``
     /// - Throws: ``PassageAPIError``
-    internal func currentUser(token: String) async throws -> PassageUserDetails {
+    internal func currentUser(token: String) async throws -> PassageUserInfo {
         let url = try self.appUrl(path: "currentuser/")
 
         let request = buildAuthenticatedRequest(url: url, method: "GET", token: token)
@@ -560,7 +560,7 @@ internal class PassageAPIClient : PassageAuthAPIClient {
         
         let changeEmailResponse = try JSONDecoder().decode(ChangeEmailResponse.self, from: responseData)
         
-        return changeEmailResponse.magic_link
+        return changeEmailResponse.magicLink
 
     }
     
@@ -598,7 +598,7 @@ internal class PassageAPIClient : PassageAuthAPIClient {
       
       let changePhoneResponse = try JSONDecoder().decode(ChangePhoneResponse.self, from: responseData)
           
-        return changePhoneResponse.magic_link
+        return changePhoneResponse.magicLink
     }
     
     /// Update the user's device, only supports the friendly name currently
@@ -643,9 +643,9 @@ internal class PassageAPIClient : PassageAuthAPIClient {
     
     /// Load a user
     /// - Parameter The identifier (email or phone) of the user to get
-    /// - Returns: ``PassageUser``
+    /// - Returns: ``PassageUserInfo``
     /// - Throws: ``PassageAPIError``
-    internal func getUser(identifier: String) async throws -> PassageUser {
+    internal func getUser(identifier: String) async throws -> PassageUserInfo {
         let url = try self.appUrl(path: "users/?identifier=\(identifier.addingPercentEncoding(withAllowedCharacters: .alphanumerics)!)")
         
         let request = buildRequest(url: url, method: "GET")
@@ -677,7 +677,7 @@ internal class PassageAPIClient : PassageAuthAPIClient {
         
         let refreshResponse = try JSONDecoder().decode(RefreshResponse.self, from: responseData)
         
-        return refreshResponse.auth_result
+        return refreshResponse.authResult
     }
     
     /// Sign out the current user's session

--- a/Sources/Passage/PassageAPIClient/PassageAPIClientModels.swift
+++ b/Sources/Passage/PassageAPIClient/PassageAPIClientModels.swift
@@ -1,153 +1,134 @@
 /// A respsonse struct for the app info request, contains a root object of type ``AppInfo``
-internal struct AppInfoResponse : Codable {
-    
+internal struct AppInfoResponse: Codable {
     /// Root element of the response of type ``AppInfo``
-    public var app: AppInfo
+    public let app: AppInfo
 }
 
 /// Details of the Public Key
-internal struct WebauthnLoginStartResponseHandshakeChallengePublicKey : Codable {
-    
+internal struct WebauthnLoginStartResponseHandshakeChallengePublicKey: Codable {
     /// The challenge to use for the Credential Assertion
-    public var challenge: String
-    
+    public let challenge: String
     /// The timeout
-    public var timeout: Int
-    
-    public var rpId: String
+    public let timeout: Int
+    public let rpId: String
 }
 
 /// Contains the Public Key to use for the credential assertion
-internal struct WebauthnLoginStartResponseHandshakeChallenge : Codable {
-    
+internal struct WebauthnLoginStartResponseHandshakeChallenge: Codable {
     /// ``WebauthnLoginStartResponseHandshakeChallengePublicKey``
-    public var publicKey: WebauthnLoginStartResponseHandshakeChallengePublicKey
+    public let publicKey: WebauthnLoginStartResponseHandshakeChallengePublicKey
 }
 
 /// Represents a handshake
-internal struct WebauthnLoginStartResponseHandshake : Codable {
-    
+internal struct WebauthnLoginStartResponseHandshake: Codable {
     /// The id of the handshake
-    public var id: String
-        
+    public let id: String
     /// ``WebauthnLoginStartResponseHandshakeChallenge``
-    public var challenge: WebauthnLoginStartResponseHandshakeChallenge
+    public let challenge: WebauthnLoginStartResponseHandshakeChallenge
 }
 
 /// API Response from a webauthn login start request
-internal struct WebauthnLoginStartResponse : Codable {
-    
+internal struct WebauthnLoginStartResponse: Codable {
     /// ``WebauthnLoginStartResponseHandshake``
-    public var handshake: WebauthnLoginStartResponseHandshake
-    
-    /// ``PassageUser`` will only be defined when logging with an identifier
-    public var user: PassageUser?
+    public let handshake: WebauthnLoginStartResponseHandshake
+    /// ``PassageUserInfo`` will only be defined when logging with an identifier
+    public let user: PassageUserInfo?
+}
+
+internal struct AuthResultResponse: Codable {
+    /// ``AuthResult``
+    public let authResult: AuthResult
+    internal enum CodingKeys: String, CodingKey {
+        case authResult = "auth_result"
+    }
+}
+
+internal struct MagicLinkResponse: Codable {
+    public let magicLink: MagicLink
+    internal enum CodingKeys: String, CodingKey {
+        case magicLink = "magic_link"
+    }
 }
 
 /// API Response from a webauthn login finish request
-internal struct WebauthnLoginFinishResponse : Codable {
-    
-    /// ``AuthResult``
-    public var auth_result: AuthResult
+internal typealias WebauthnLoginFinishResponse = AuthResultResponse
+
+internal struct WebauthnRegisterStartResponseHandshakeChallengePublicKeyPubKeyCredParam: Codable {
+    public let alg: Int
+    public let type: String
 }
 
-internal struct WebauthnRegisterStartResponseHandshakeChallengePublicKeyPubKeyCredParam : Codable {
-    public var alg: Int
-    public var type: String
+internal struct WebauthnRegisterStartResponseHandshakeChallengePublicKeyRelyingParty: Codable {
+    public let name: String
+    public let id: String
 }
 
-internal struct WebauthnRegisterStartResponseHandshakeChallengePublicKeyRelyingParty : Codable {
-    public var name: String
-    public var id: String
+internal struct WebauthnRegisterStartResponseHandshakeChallengePublicKeyUser: Codable {
+    public let displayName: String
+    public let id: String
+    public let name: String
 }
 
-internal struct WebauthnRegisterStartResponseHandshakeChallengePublicKeyUser : Codable {
-    public var displayName: String
-    public var id: String
-    public var name: String
+internal struct WebauthnRegisterStartResponseHandshakeChallengePublicKeyAuthenticatorSelection: Codable {
+    public let authenticatorAttachment: String
 }
 
-internal struct WebauthnRegisterStartResponseHandshakeChallengePublicKeyAuthenticatorSelection : Codable {
-    public var authenticatorAttachment: String
+internal struct WebauthnRegisterStartResponseHandshakeChallengePublicKey: Codable {
+    public let attestation: String
+    public let pubKeyCredParams: [WebauthnRegisterStartResponseHandshakeChallengePublicKeyPubKeyCredParam]
+    public let rp: WebauthnRegisterStartResponseHandshakeChallengePublicKeyRelyingParty
+    public let user: WebauthnRegisterStartResponseHandshakeChallengePublicKeyUser
+    public let challenge: String
+    public let authenticatorSelection: WebauthnRegisterStartResponseHandshakeChallengePublicKeyAuthenticatorSelection
+    public let timeout: Int
 }
 
-internal struct WebauthnRegisterStartResponseHandshakeChallengePublicKey : Codable {
-    public var attestation: String
-    public var pubKeyCredParams: [WebauthnRegisterStartResponseHandshakeChallengePublicKeyPubKeyCredParam]
-    public var rp: WebauthnRegisterStartResponseHandshakeChallengePublicKeyRelyingParty
-    public var user: WebauthnRegisterStartResponseHandshakeChallengePublicKeyUser
-    public var challenge: String
-    public var authenticatorSelection: WebauthnRegisterStartResponseHandshakeChallengePublicKeyAuthenticatorSelection
-    public var timeout: Int
+internal struct WebauthnRegisterStartResponseHandshakeChallenge: Codable {
+    public let publicKey: WebauthnRegisterStartResponseHandshakeChallengePublicKey
 }
 
-internal struct WebauthnRegisterStartResponseHandshakeChallenge : Codable {
-    public var publicKey: WebauthnRegisterStartResponseHandshakeChallengePublicKey
-}
-
-internal struct WebauthnRegisterStartResponseHandshake : Codable {
-    public var id: String
-    public var challenge: WebauthnRegisterStartResponseHandshakeChallenge
+internal struct WebauthnRegisterStartResponseHandshake: Codable {
+    public let id: String
+    public let challenge: WebauthnRegisterStartResponseHandshakeChallenge
 }
 
 /// API Response from a webauthn registration start request
-internal struct WebauthnRegisterStartResponse : Codable {
-    public var user: PassageUser
-    public var handshake: WebauthnRegisterStartResponseHandshake
+internal struct WebauthnRegisterStartResponse: Codable {
+    public let user: PassageUserInfo
+    public let handshake: WebauthnRegisterStartResponseHandshake
 }
 
 /// API Response from webauthn registration finish
-internal struct WebauthnRegisterFinishResponse : Codable {
-    
-    /// ``AuthResult``
-    public var auth_result: AuthResult
+internal typealias WebauthnRegisterFinishResponse = AuthResultResponse
+
+internal typealias WebauthnAddDeviceFinishResponse = AuthResultResponse
+
+internal typealias SendMagicLinkResponse = MagicLinkResponse
+
+internal typealias MagicLinkStatusResponse = AuthResultResponse
+
+internal typealias ActivateMagicLinkResponse = AuthResultResponse
+
+internal typealias ActivateOneTimePasscodeResponse = AuthResultResponse
+
+internal struct CurrentUserResponse: Codable {
+    public let user: PassageUserInfo
 }
 
-internal struct WebauthnAddDeviceFinishResponse : Codable {
-    /// ``AuthResult``
-    public var auth_result: AuthResult
+internal struct ListDevicesResponse: Codable {
+    public let devices: [DeviceInfo]
 }
 
-internal struct SendMagicLinkResponse : Codable {
-    public var magic_link: MagicLink
+internal typealias ChangeEmailResponse = MagicLinkResponse
+
+internal typealias ChangePhoneResponse = MagicLinkResponse
+
+internal struct UpdateDeviceResponse: Codable {
+    public let device: DeviceInfo
 }
 
-internal struct MagicLinkStatusResponse : Codable {
-    public var auth_result: AuthResult
+internal struct GetUserResponse: Codable {
+    public let user: PassageUserInfo
 }
 
-internal struct ActivateMagicLinkResponse : Codable {
-    public var auth_result: AuthResult
-}
-
-internal struct ActivateOneTimePasscodeResponse : Codable {
-    public var auth_result: AuthResult
-}
-
-internal struct CurrentUserResponse : Codable {
-    public var user: PassageUserDetails
-}
-
-internal struct ListDevicesResponse : Codable {
-    public var devices: [DeviceInfo]
-}
-
-internal struct ChangeEmailResponse : Codable {
-    public var magic_link: MagicLink
-}
-
-internal struct ChangePhoneResponse : Codable {
-    public var magic_link: MagicLink
-}
-
-internal struct UpdateDeviceResponse : Codable {
-    public var device: DeviceInfo
-}
-
-internal struct GetUserResponse : Codable {
-    public var user: PassageUser
-}
-
-internal struct RefreshResponse : Codable {
-    public var auth_result: AuthResult
-}
+internal typealias RefreshResponse = AuthResultResponse

--- a/Sources/Passage/PassageAPIClient/PassageAPIClientModels.swift
+++ b/Sources/Passage/PassageAPIClient/PassageAPIClientModels.swift
@@ -1,18 +1,9 @@
-//
-//  PassageAPIClientModels.swift
-//  Shiny
-//
-//  Created by blayne bayer on 8/23/22.
-//  Copyright © 2022 Apple. All rights reserved.
-//
-
 /// A respsonse struct for the app info request, contains a root object of type ``AppInfo``
 internal struct AppInfoResponse : Codable {
     
     /// Root element of the response of type ``AppInfo``
     public var app: AppInfo
 }
-
 
 /// Details of the Public Key
 internal struct WebauthnLoginStartResponseHandshakeChallengePublicKey : Codable {
@@ -129,11 +120,13 @@ internal struct ActivateMagicLinkResponse : Codable {
     public var auth_result: AuthResult
 }
 
+internal struct ActivateOneTimePasscodeResponse : Codable {
+    public var auth_result: AuthResult
+}
 
 internal struct CurrentUserResponse : Codable {
     public var user: PassageUserDetails
 }
-
 
 internal struct ListDevicesResponse : Codable {
     public var devices: [DeviceInfo]
@@ -158,5 +151,3 @@ internal struct GetUserResponse : Codable {
 internal struct RefreshResponse : Codable {
     public var auth_result: AuthResult
 }
-
-

--- a/Sources/Passage/PassageAPIClient/PassageAPIClientProtocol.swift
+++ b/Sources/Passage/PassageAPIClient/PassageAPIClientProtocol.swift
@@ -140,8 +140,8 @@ protocol PassageAuthAPIClient  {
     
     /// Get the detail for the current user
     /// - Parameter token: The user's access token
-    /// - Returns: ``PassageUserDetails``
-    func currentUser(token: String) async throws -> PassageUserDetails
+    /// - Returns: ``PassageUserInfo``
+    func currentUser(token: String) async throws -> PassageUserInfo
     
     
     /// Make a request to get the current user's devices
@@ -191,8 +191,8 @@ protocol PassageAuthAPIClient  {
     
     /// Load a user
     /// - Parameter The identifier (email or phone) of the user to get
-    /// - Returns: ``PassageUser``
-    func getUser(identifier: String) async throws -> PassageUser
+    /// - Returns: ``PassageUserInfo``
+    func getUser(identifier: String) async throws -> PassageUserInfo
     
     /// Refresh a session using a refresh token
     ///  - Parameter The user's refresh token

--- a/Sources/Passage/PassageAPIClient/PassageAPIClientProtocol.swift
+++ b/Sources/Passage/PassageAPIClient/PassageAPIClientProtocol.swift
@@ -1,12 +1,3 @@
-//
-//  PassageAPIClientProtocol.swift
-//  Shiny
-//
-//  Created by blayne bayer on 8/23/22.
-//  Copyright © 2022 Apple. All rights reserved.
-//
-
-import Foundation
 import AuthenticationServices
 
 /// Protocol that any Passage API Client must implement
@@ -123,6 +114,30 @@ protocol PassageAuthAPIClient  {
     func activateMagicLink(magicLink: String) async throws -> AuthResult
     
     
+    /// Send a new login one time passcode to the user's email or phone
+    /// - Parameters:
+    ///   - identifier: The users email or phone number
+    ///   - language: optional language string for localizing emails, if no lanuage or an invalid language is provided the application default lanuage will be used
+    /// - Returns: ``OneTimePasscode``
+    func sendLoginOneTimePasscode(identifier: String, language: String?) async throws -> OneTimePasscode
+    
+    
+    /// Send a new registration one time passcode to the user's email or phone
+    /// - Parameters:
+    ///   - identifier: The users email or phone number
+    ///   - language: optional language string for localizing emails, if no lanuage or an invalid language is provided the application default lanuage will be used
+    /// - Returns: ``OneTimePasscode``
+    func sendRegisterOneTimePasscode(identifier: String, language: String?) async throws -> OneTimePasscode
+    
+    
+    /// Active a magic link
+    /// - Parameters:
+    ///   - otp: The one time passcode to activate
+    ///   - otpId: The one time passcode id
+    /// - Returns: ``AuthResult``
+    func activateOneTimePasscode(otp: String, otpId: String) async throws -> AuthResult
+    
+    
     /// Get the detail for the current user
     /// - Parameter token: The user's access token
     /// - Returns: ``PassageUserDetails``
@@ -191,5 +206,3 @@ protocol PassageAuthAPIClient  {
     /// - Throws: ``PassageAPIError``
     func signOut(refreshToken: String) async throws
 }
-
-

--- a/Sources/Passage/PassageAuth.swift
+++ b/Sources/Passage/PassageAuth.swift
@@ -449,7 +449,7 @@ public class PassageAuth {
             }
             return (nil, authFallbackResult)
         }
-        let authResult = try? await PassageAuth.registerWithPasskey(identifier: identifier)
+        let authResult = try await PassageAuth.registerWithPasskey(identifier: identifier)
         return (authResult, nil)
     }
     

--- a/Sources/Passage/PassageAuth.swift
+++ b/Sources/Passage/PassageAuth.swift
@@ -1,11 +1,3 @@
-//
-//  self.swift
-//  Shiny
-//
-//  Created by blayne bayer on 8/9/22.
-//  Copyright © 2022 Apple. All rights reserved.
-//
-
 import AuthenticationServices
 import os
 
@@ -78,7 +70,7 @@ public class PassageAuth {
     ///   - onCancel: function to run if the user cancels the Passkey login
     /// - Returns: Void
     @available(iOS 16.0, *)
-    public func beginAutoFill(onSuccess:  ((AuthResult) -> Void)?, onError: ((Error) -> Void)?, onCancel: (() -> Void)?) async throws -> Void {
+    public func beginAutoFill(anchor: ASPresentationAnchor, onSuccess:  ((AuthResult) -> Void)?, onError: ((Error) -> Void)?, onCancel: (() -> Void)?) async throws -> Void {
         self.clearTokens()
 
         func onAutofillSuccess(authResult: AuthResult) -> Void {
@@ -89,7 +81,7 @@ public class PassageAuth {
             }
 
         }
-        try await PassageAutofillAuthorizationController.shared.begin(onSuccess: onAutofillSuccess, onError: onError, onCancel: onCancel)
+        try await PassageAutofillAuthorizationController.shared.begin(anchor: anchor, onSuccess: onAutofillSuccess, onError: onError, onCancel: onCancel)
 
     }
     
@@ -628,7 +620,6 @@ public class PassageAuth {
             throw PassageError.unknown
         }
     }
-        
     
     /// Sign out the current user's session
     ///
@@ -795,6 +786,65 @@ public class PassageAuth {
             throw PassageError.unknown
         }
     }
+    
+    /// Creates and sends a one time passcode to the user. The user will receive an email or text to complete the registration.
+    ///
+    /// - Parameters:
+    ///   - identifier: string - email or phone number, depending on your app settings
+    ///   - language: optional language string for localizing emails, if no lanuage or an invalid language is provided the application default lanuage will be used
+    /// - Returns: ``OneTimePasscode``
+    /// - Throws: ``PassageAPIError``, ``PassageError``
+    public static func newRegisterOneTimePasscode(identifier: String, language: String? = nil) async throws -> OneTimePasscode {
+        do {
+            let oneTimePasscode = try await PassageAPIClient.shared.sendRegisterOneTimePasscode(identifier: identifier, language: language)
+            return oneTimePasscode
+        } catch {
+            if let error = error as? PassageAPIError {
+                try PassageAuth.handlePassageAPIError(error: error)
+            }
+            throw error
+        }
+    }
+    
+    /// Creates and sends a one time passcode to login the user. The user will receive an email or text to complete the login.
+    /// - Parameters:
+    ///   - identifier: string - email or phone number, depending on your app settings
+    ///   - language: optional language string for localizing emails, if no lanuage or an invalid language is provided the application default lanuage will be used
+    /// - Returns: ``OneTimePasscode``
+    /// - Throws: ``PassageAPIError``, ``PassageError``
+    public static func newLoginOneTimePasscode(identifier: String, language: String? = nil) async throws -> OneTimePasscode {
+        do {
+            let oneTimePasscode = try await PassageAPIClient.shared.sendLoginOneTimePasscode(identifier: identifier, language: language)
+            return oneTimePasscode
+        } catch {
+            if let error = error as? PassageAPIError {
+                try PassageAuth.handlePassageAPIError(error: error)
+            }
+            throw error
+        }
+    }
+    
+    /// Completes a one time passcode login workflow by activating the one time passcode.
+    ///
+    /// Used to activate either a login or registration one time passcode.
+    ///
+    /// - Parameters:
+    ///   - otp: The user's one time passcode
+    ///   - otpId: The one time passcode id
+    /// - Returns: ``AuthResult`` The AuthResult object contains an authentication token (JWT) and redirect URL. The auth token should be used on all subsequent authenticated requests to the app. The redirect URL specifies the route that users should be redirected to after completed registration or login
+    /// - Throws: ``PassageAPIError``, ``PassageError``
+    public static func oneTimePasscodeActivate(otp: String, otpId: String) async throws -> AuthResult {
+        do {
+            let authResult = try await PassageAPIClient.shared.activateOneTimePasscode(otp: otp, otpId: otpId)
+            return authResult
+        } catch {
+            if let error = error as? PassageAPIError {
+                try PassageAuth.handlePassageAPIError(error: error)
+            }
+            throw error
+        }
+    }
+    
            
     /// This method fetches the user by the specified token.
     /// - Parameter token: an auth token from the AuthResult object
@@ -1184,8 +1234,8 @@ public class PassageAuth {
     ///   - onCancel: function to run if the user cancels the Passkey login
     /// - Returns: Void
     @available(iOS 16.0, *)
-    public static func beginAutoFill(onSuccess:  ((AuthResult) -> Void)?, onError: ((Error) -> Void)?, onCancel: (() -> Void)?) async throws -> Void {
-        try await PassageAutofillAuthorizationController.shared.begin(onSuccess: onSuccess, onError: onError, onCancel: onCancel)
+    public static func beginAutoFill(anchor: ASPresentationAnchor, onSuccess:  ((AuthResult) -> Void)?, onError: ((Error) -> Void)?, onCancel: (() -> Void)?) async throws -> Void {
+        try await PassageAutofillAuthorizationController.shared.begin(anchor: anchor, onSuccess: onSuccess, onError: onError, onCancel: onCancel)
     }
 
 }

--- a/Sources/Passage/PassageErrors.swift
+++ b/Sources/Passage/PassageErrors.swift
@@ -1,16 +1,7 @@
-//
-//  PassageErrors.swift
-//  Shiny
-//
-//  Created by Ricky C Padilla on 8/8/22.
-//  Copyright © 2022 Apple. All rights reserved.
-//
-
 import Foundation
 
-
 /// Errors thrown from the ASAuthorization Controller
-public enum PassageASAuthorizationError : Error {
+public enum PassageASAuthorizationError: Error {
     case authorizationTypeUnknown
     case canceled
     case credentialRegistration
@@ -38,10 +29,12 @@ public enum PassageError: Error, Equatable {
     case userAlreadyExists
     case userDoesNotExist
     case invalidAppInfo
+    case invalidAuthFallbackMethod
+    case authFallbacksNotSupported
 }
 
 /// Passage Device Errors
-public enum PassageDeviceError : Error {
+public enum PassageDeviceError: Error {
     case notFound
 }
 

--- a/Sources/Passage/PassageModels.swift
+++ b/Sources/Passage/PassageModels.swift
@@ -1,84 +1,73 @@
 import Foundation
 
 /// The authentication result containing the users tokens and redirect url
-public struct AuthResult : Codable {
-    /// The users auth_token
-    public var auth_token: String?
-    
-    /// The users refresh_token
-    public var refresh_token: String?
-    
+public struct AuthResult: Codable {
+    /// The user's auth token
+    public let authToken: String
     /// The redirect url after successful authentication
-    public var redirect_url: String?
+    public let redirectURL: String
+    /// The user's refresh token
+    public let refreshToken: String?
+    /// The expiration of the user's refresh token
+    public let refreshTokenExpiration: Int?
+    
+    internal enum CodingKeys: String, CodingKey {
+        case authToken = "auth_token"
+        case redirectURL = "redirect_url"
+        case refreshToken = "refresh_token"
+        case refreshTokenExpiration = "refresh_token_expiration"
+    }
 }
 
-
-/// Details of a Passage User
-public struct PassageUser : Codable, Equatable {
-
-    /// The user's id in the Passage System
-    public var id: String
-    
-    /// User status,
-    public var status: String?
-
-    /// The user's email address
-    public var email: String?
-
-    /// Whether the users email has been verifier or not
-    public var email_verified: Bool
-    
-    /// Users phone number
-    public var phone: String?
-    
-    /// Whether the user's phone number has been verified
-    public var phone_verified: Bool
-    
-    /// Does the user support webauthn
-    public var webauthn: Bool
-    
-    /// Uer meta data schema
-    public var user_metadata: String?
-    
-    /// Types of webauth - platform or passkey
-    public var webauthn_types: [String]?
-    
-}
-
-/// Details about a Passage user
-public struct PassageUserDetails : Codable {
+/// Information about a Passage user
+public struct PassageUserInfo: Codable {
     /// when the user was created
-    public var created_at: String
-    /// when the user was last update
-    public var updated_at: String
-    /// status of the user
-    public var status: String
-    /// the user's unique id
-    public var id: String
+    public let createdAt: String?
     /// user's email address
-    public var email: String
+    public let email: String?
     /// has the user's email been verified
-    public var email_verified: Bool
-    /// user's phone number
-    public var phone: String
-    /// has the user's phone number been verified
-    public var phone_verified: Bool
-    /// does the user support webauthn
-    public var webauthn: Bool
+    public let emailVerified: Bool
+    /// the user's unique id
+    public let id: String
     /// last time the user logged in
-    public var last_login_at: String
+    public let lastLoginAt: String?
     /// number of times the user has logged in
-    public var login_count: Int
-    //    var user_metadata: [String: String]
+    public let loginCount: Int?
+    /// user's phone number
+    public let phone: String?
+    /// has the user's phone number been verified
+    public let phoneVerified: Bool
+    /// status of the user
+    public let status: String
+    /// when the user was last update
+    public let updatedAt: String?
+    /// does the user support webauthn
+    public let webauthn: Bool?
     /// Devices the user has used webauthn on
-    public var webauthn_devices: [WebauthnDevice]
+    public let webauthnDevices: [WebauthnDevice]?
     /// types of webauthn the user has used - passkey or platform
-    public var webauthn_types: [String]
+    public let webauthnTypes: [String]?
+    
+    internal enum CodingKeys: String, CodingKey {
+        case createdAt = "created_at"
+        case email
+        case emailVerified = "email_verified"
+        case id
+        case lastLoginAt = "last_login_at"
+        case loginCount = "login_count"
+        case phone
+        case phoneVerified = "phone_verified"
+        case status
+        case updatedAt = "updated_at"
+        case webauthn
+        case webauthnDevices = "webauthn_devices"
+        case webauthnTypes = "webauthn_types"
+    }
 }
 
 
 /// Devices used with webauthn
-public struct WebauthnDevice : Codable {
+public struct WebauthnDevice: Codable {
     public var id: String
 }
 
@@ -160,21 +149,32 @@ public struct OneTimePasscode: AuthFallbackResult {
 }
 
 /// Information about a registered device
-public struct DeviceInfo : Codable {
-    /// The device id
-    public var id: String
-    /// The id of the credential this device is registered with
-    public var cred_id: String
-    /// The user id associated with the device
-    public var user_id: String
-    /// A friendly name to describe the device
-    public var friendly_name: String
-    /// Number of times the device has been used
-    public var usage_count: Int
-    /// When the device was last updated.
-    public var updated_at: String
+public struct DeviceInfo: Codable {
     /// When the device was initially registered
-    public var created_at: String
+    public let createdAt: String
+    /// The id of the credential this device is registered with
+    public let credId: String
+    /// A friendly name to describe the device
+    public let friendlyName: String
+    /// The device id
+    public let id: String
     /// Last time the device was used.
-    public var last_login_at: String
+    public let lastLoginAt: String
+    /// When the device was last updated.
+    public let updatedAt: String?
+    /// Number of times the device has been used
+    public let usageCount: Int?
+    /// The user id associated with the device
+    public let userId: String
+    
+    internal enum CodingKeys: String, CodingKey {
+        case createdAt = "created_at"
+        case credId = "cred_id"
+        case friendlyName = "friendly_name"
+        case id
+        case lastLoginAt = "last_login_at"
+        case updatedAt = "updated_at"
+        case usageCount = "usage_count"
+        case userId = "user_id"
+    }
 }

--- a/Sources/Passage/PassageModels.swift
+++ b/Sources/Passage/PassageModels.swift
@@ -1,10 +1,3 @@
-//
-//  File.swift
-//  
-//
-//  Created by blayne bayer on 8/31/22.
-//
-
 import Foundation
 
 /// The authentication result containing the users tokens and redirect url
@@ -148,6 +141,15 @@ public struct AppInfo : Codable, Equatable {
 public struct MagicLink : Codable {
     /// id of the magic link
     public var id: String
+}
+
+/// Describes a one time passcode
+public struct OneTimePasscode : Codable {
+    /// id of the one time passcode
+    public let id: String
+    enum CodingKeys: String, CodingKey {
+        case id = "otp_id"
+    }
 }
 
 /// Information about a registered device

--- a/Sources/Passage/PassageModels.swift
+++ b/Sources/Passage/PassageModels.swift
@@ -83,70 +83,77 @@ public struct WebauthnDevice : Codable {
 }
 
 /// Struct describing a Passage Application
-public struct AppInfo : Codable, Equatable {
-    
-    /// The id of the Passage Application
-    public var id: String
-    
-    
-    /// If this is an ephemeral app
-    public var ephemeral: Bool
-    
-    
-    /// The name of the Passage Application
-    public var name: String
-    
-    
-    /// The Pasage Application redirect url
-    public var redirect_url: String
-    
-    
-    /// The Login URL of the Passage Application
-    public var login_url: String
-    
-    
+public struct AppInfo: Codable, Equatable {
     /// Allowed identifier (email or phone)
-    public var allowed_identifier: String
-    
-    /// The identifier type that is required
-    public var required_identifier: String
-    
-    
+    public let allowedIdentifier: String
+    /// String representation of which fallback method is set in the Passage Application when Passkeys are not available
+    internal let authFallbackMethodString: String
     /// The Passage Applications auth origin
-    public var auth_origin: String
-    
-    
-    /// Whether the Passage Application requires email verificiation
-    public var require_email_verification: Bool
-    
-    
-    /// Whether the Passage Application required identifier verification when registering
-    public var require_identifier_verification: Bool
-    
-    
-    /// How long is the auth token valid
-    public var session_timeout_length: Int
-
-    //    var user_metadata_schema: [String: String]
-
-    //    var layouts: [String: String]
-    
-    
+    public let authOrigin: String
+    /// If this is an ephemeral app
+    public let ephemeral: Bool
+    /// The id of the Passage Application
+    public let id: String
+    /// The Login URL of the Passage Application
+    public let loginURL: String
+    /// The name of the Passage Application
+    public let name: String
     /// Allow public signup
-    public var public_signup: Bool
+    public let publicSignup: Bool
+    /// The Pasage Application redirect url
+    public let redirectURL: String
+    /// The identifier type that is required
+    public let requiredIdentifier: String
+    /// Whether the Passage Application requires email verificiation
+    public let requireEmailVerification: Bool
+    /// Whether the Passage Application required identifier verification when registering
+    public let requireIdentifierVerification: Bool
+    /// How long is the auth token valid
+    public let sessionTimeoutLength: Int
+
+    internal enum CodingKeys: String, CodingKey {
+        case allowedIdentifier = "allowed_identifier"
+        case authFallbackMethodString = "auth_fallback_method"
+        case authOrigin = "auth_origin"
+        case ephemeral
+        case id
+        case loginURL = "login_url"
+        case name
+        case publicSignup = "public_signup"
+        case redirectURL = "redirect_url"
+        case requiredIdentifier = "required_identifier"
+        case requireEmailVerification = "require_email_verification"
+        case requireIdentifierVerification = "require_identifier_verification"
+        case sessionTimeoutLength = "session_timeout_length"
+    }
+    
+    public enum AuthFallbackMethod: String {
+        case magicLink = "magic_link"
+        case oneTimePasscode = "otp"
+        case none = "none"
+    }
+    
+    /// Which fallback method is set in the Passage Application when Passkeys are not available
+    public var authFallbackMethod: AuthFallbackMethod? {
+        return AuthFallbackMethod(rawValue: authFallbackMethodString)
+    }
+    
 }
 
+public protocol AuthFallbackResult: Codable {
+    var id: String { get set }
+}
 
 /// Describes a magic link
-public struct MagicLink : Codable {
+public struct MagicLink: AuthFallbackResult {
     /// id of the magic link
     public var id: String
 }
 
 /// Describes a one time passcode
-public struct OneTimePasscode : Codable {
+public struct OneTimePasscode: AuthFallbackResult {
     /// id of the one time passcode
-    public let id: String
+    public var id: String
     enum CodingKeys: String, CodingKey {
         case id = "otp_id"
     }

--- a/Sources/Passage/PassageStore.swift
+++ b/Sources/Passage/PassageStore.swift
@@ -83,8 +83,8 @@ public class PassageStore : PassageTokenStore {
     }
     
     public func setTokens(authResult: AuthResult) {
-        self.authToken = authResult.auth_token
-        self.refreshToken = authResult.refresh_token
+        self.authToken = authResult.authToken
+        self.refreshToken = authResult.refreshToken
     }
     
     public func setTokens(authToken: String?, refreshToken: String?) {

--- a/Tests/Integration/IntegrationTestData.swift
+++ b/Tests/Integration/IntegrationTestData.swift
@@ -46,64 +46,65 @@ let currentUser = PassageUserDetails(
 
 
 let appInfoValid = AppInfo(
-    id: "czLTOVFIytGqrhRVoHV9o8Wo",
+    allowedIdentifier: "both",
+    authFallbackMethodString: "magic_link",
+    authOrigin: "http://localhost:4173",
     ephemeral: false,
+    id: "czLTOVFIytGqrhRVoHV9o8Wo",
+    loginURL: "/",
     name: "passage-ios uat",
-    redirect_url: "/dashboard",
-    login_url: "/",
-    allowed_identifier: "both",
-    required_identifier: "both",
-    auth_origin: "http://localhost:4173",
-    require_email_verification: false,
-    require_identifier_verification: false,
-    session_timeout_length: 0,
-    public_signup: true
+    publicSignup: true,
+    redirectURL: "/dashboard",
+    requiredIdentifier: "both",
+    requireEmailVerification: false,
+    requireIdentifierVerification: false,
+    sessionTimeoutLength: 0
 )
 
 let appInfoInvalid = AppInfo(
-    id: "TEST_APP_ID",
+    allowedIdentifier: "TEST_ALLOWED_IDENTIFIER",
+    authFallbackMethodString: "magic_link",
+    authOrigin: "TEST_AUTH_ORIGIN",
     ephemeral: true,
+    id: "TEST_APP_ID",
+    loginURL: "TEST_LOGIN_URL",
     name: "TEST_APP",
-    redirect_url: "TEST_APP_URL",
-    login_url: "TEST_LOGIN_URL",
-    allowed_identifier: "TEST_ALLOWED_IDENTIFIER",
-    required_identifier: "TEST_REQUIRED_IDENTIFIER",
-    auth_origin: "TEST_AUTH_ORIGIN",
-    require_email_verification: false,
-    require_identifier_verification: false,
-    session_timeout_length: 6000,
-    public_signup: true
+    publicSignup: true,
+    redirectURL: "TEST_APP_URL",
+    requiredIdentifier: "TEST_REQUIRED_IDENTIFIER",
+    requireEmailVerification: false,
+    requireIdentifierVerification: false,
+    sessionTimeoutLength: 6000
 )
 
 let appInfoRefreshToken = AppInfo(
-    id: "uFZlFit7nglPuzcYRVesCUBZ",
+    allowedIdentifier: "both",
+    authFallbackMethodString: "magic_link",
+    authOrigin: "http://localhost:4173",
     ephemeral: false,
+    id: "uFZlFit7nglPuzcYRVesCUBZ",
+    loginURL: "/",
     name: "passage-ios uat refresh tokens",
-    redirect_url: "/dashboard",
-    login_url: "/",
-    allowed_identifier: "both",
-    required_identifier: "both",
-    auth_origin: "http://localhost:4173",
-    require_email_verification: false,
-    require_identifier_verification: false,
-    session_timeout_length: 5,
-    public_signup: true
+    publicSignup: true,
+    redirectURL: "/dashboard",
+    requiredIdentifier: "both",
+    requireEmailVerification: false,
+    requireIdentifierVerification: false,
+    sessionTimeoutLength: 5
 )
 
-
-
-
 let appInfoTest = AppInfo(
-    id: "TEST_APP_ID",
+    allowedIdentifier: "TEST_ALLOWED_IDENTIFIER",
+    authFallbackMethodString: "magic_link",
+    authOrigin: "TEST_AUTH_ORIGIN",
     ephemeral: true,
+    id: "TEST_APP_ID",
+    loginURL: "TEST_LOGIN_URL",
     name: "TEST_APP",
-    redirect_url: "TEST_APP_URL",
-    login_url: "TEST_LOGIN_URL",
-    allowed_identifier: "TEST_ALLOWED_IDENTIFIER",
-    required_identifier: "TEST_REQUIRED_IDENTIFIER",
-    auth_origin: "TEST_AUTH_ORIGIN",
-    require_email_verification: false,
-    require_identifier_verification: false,
-    session_timeout_length: 6000,
-    public_signup: true
+    publicSignup: true,
+    redirectURL: "TEST_APP_URL",
+    requiredIdentifier: "TEST_REQUIRED_IDENTIFIER",
+    requireEmailVerification: false,
+    requireIdentifierVerification: false,
+    sessionTimeoutLength: 6000
 )

--- a/Tests/Integration/IntegrationTestData.swift
+++ b/Tests/Integration/IntegrationTestData.swift
@@ -108,3 +108,31 @@ let appInfoTest = AppInfo(
     requireIdentifierVerification: false,
     sessionTimeoutLength: 6000
 )
+
+let otpAppInfoValid = AppInfo(
+    allowedIdentifier: "both",
+    authFallbackMethodString: "otp",
+    authOrigin: "http://localhost:4173",
+    ephemeral: false,
+    id: "pTBeTnbvm1z3U6hznMTD33Es",
+    loginURL: "/",
+    name: "UAT OTP App",
+    publicSignup: true,
+    redirectURL: "/dashboard",
+    requiredIdentifier: "both",
+    requireEmailVerification: false,
+    requireIdentifierVerification: false,
+    sessionTimeoutLength: 6000
+)
+
+let otpRegisteredUser = PassageUser(
+    id: "oiySQzEcqEpzxX3yu5cKKRKe",
+    status: "active",
+    email:"authentigator+1681334202.318723@passage.id",
+    email_verified: true,
+    phone: "",
+    phone_verified: false,
+    webauthn: false,
+    user_metadata: nil,
+    webauthn_types: []
+)

--- a/Tests/Integration/IntegrationTestData.swift
+++ b/Tests/Integration/IntegrationTestData.swift
@@ -1,10 +1,3 @@
-//
-//  File.swift
-//  
-//
-//  Created by blayne bayer on 2/14/23.
-//
-
 import AuthenticationServices
 @testable import Passage
 
@@ -16,32 +9,36 @@ let mailosaurAPIKey = ProcessInfo.processInfo.environment["MAILOSAUR_API_KEY"]!
 let unregisteredUserEmail = "unregistered-test-user@passage.id"
 let registeredUserEmail = "blayne.bayer+integrationtest@passge.id"
 
-let registeredUser = PassageUser(
-    id: "BMQ9Jbi90ubPvX9H1XU5oyfR",
-    status: "active",
+let registeredUser = PassageUserInfo(
+    createdAt: "",
     email:"blayne.bayer@passage.id",
-    email_verified: true,
+    emailVerified: true,
+    id: "BMQ9Jbi90ubPvX9H1XU5oyfR",
+    lastLoginAt: "",
+    loginCount: 1,
     phone: "",
-    phone_verified: false,
+    phoneVerified: false,
+    status: "active",
+    updatedAt: "",
     webauthn: true,
-    user_metadata: nil,
-    webauthn_types: []
+    webauthnDevices: [],
+    webauthnTypes: []
 )
 
-let currentUser = PassageUserDetails(
-    created_at: "2023-02-16T15:55:28.890571Z",
-    updated_at: "2023-02-16T19:55:38.909048Z",
-    status: "active",
-    id: "BMQ9Jbi90ubPvX9H1XU5oyfR",
+let currentUser = PassageUserInfo(
+    createdAt: "2023-02-16T15:55:28.890571Z",
     email: "blayne.bayer@passage.id",
-    email_verified: true,
+    emailVerified: true,
+    id: "BMQ9Jbi90ubPvX9H1XU5oyfR",
+    lastLoginAt: "2023-02-16T19:55:38.907657Z",
+    loginCount: 2,
     phone: "",
-    phone_verified: false,
+    phoneVerified: false,
+    status: "active",
+    updatedAt: "2023-02-16T19:55:38.909048Z",
     webauthn: true,
-    last_login_at: "2023-02-16T19:55:38.907657Z",
-    login_count: 2,
-    webauthn_devices: [],
-    webauthn_types: []
+    webauthnDevices: [],
+    webauthnTypes: []
 )
 
 
@@ -125,14 +122,18 @@ let otpAppInfoValid = AppInfo(
     sessionTimeoutLength: 6000
 )
 
-let otpRegisteredUser = PassageUser(
-    id: "oiySQzEcqEpzxX3yu5cKKRKe",
-    status: "active",
+let otpRegisteredUser = PassageUserInfo(
+    createdAt: "",
     email:"authentigator+1681334202.318723@passage.id",
-    email_verified: true,
+    emailVerified: true,
+    id: "oiySQzEcqEpzxX3yu5cKKRKe",
+    lastLoginAt: "",
+    loginCount: 1,
     phone: "",
-    phone_verified: false,
+    phoneVerified: false,
+    status: "active",
+    updatedAt: "",
     webauthn: false,
-    user_metadata: nil,
-    webauthn_types: []
+    webauthnDevices: [],
+    webauthnTypes: []
 )

--- a/Tests/Integration/PassageAPIClient/AppInfoTests.swift
+++ b/Tests/Integration/PassageAPIClient/AppInfoTests.swift
@@ -1,10 +1,3 @@
-//
-//  testss.swift
-//  
-//
-//  Created by blayne bayer on 2/14/23.
-//
-
 import XCTest
 @testable import Passage
 
@@ -42,7 +35,7 @@ final class AppInfoTests: XCTestCase {
             
             if let thrownError = error as? PassageAPIError {
                 switch thrownError {
-                    case .notFound(let response):
+                    case .notFound:
                         XCTAssertTrue(true)
                 default:
                     XCTAssertFalse(true)
@@ -51,6 +44,5 @@ final class AppInfoTests: XCTestCase {
         }
         
     }
-    
 
 }

--- a/Tests/Integration/PassageAPIClient/AppInfoTests.swift
+++ b/Tests/Integration/PassageAPIClient/AppInfoTests.swift
@@ -27,7 +27,7 @@ final class AppInfoTests: XCTestCase {
     func testAppInfoNotFound() async {
         do {
             PassageAPIClient.shared.appId = appInfoInvalid.id
-            let response = try await PassageAPIClient.shared.appInfo();
+            let _ = try await PassageAPIClient.shared.appInfo();
             XCTAssertFalse(true)
         }
         catch  {

--- a/Tests/Integration/PassageAPIClient/ChangeContactTests.swift
+++ b/Tests/Integration/PassageAPIClient/ChangeContactTests.swift
@@ -29,7 +29,7 @@ final class ChangeContactTests: XCTestCase {
     func testChangeEmailUnAuthed() async {
         do {
             PassageAPIClient.shared.appId = appInfoValid.id
-            let response = try await PassageAPIClient.shared
+            let _ = try await PassageAPIClient.shared
                 .changeEmail(token: "", newEmail: "blayne.bayer+2@passage.id", magicLinkPath: nil, redirectUrl: nil, language: nil)
             XCTAssertTrue(false)
         } catch {
@@ -63,7 +63,7 @@ final class ChangeContactTests: XCTestCase {
         XCTAssertNotEqual(authToken, "")
         do {
             PassageAPIClient.shared.appId = appInfoValid.id
-            let response = try await PassageAPIClient.shared
+            let _ = try await PassageAPIClient.shared
                 .changePhone(token: authToken, newPhone: "5125874725", magicLinkPath: nil, redirectUrl: nil, language: nil)
             XCTAssertTrue(false)
         } catch {
@@ -83,7 +83,7 @@ final class ChangeContactTests: XCTestCase {
     func testChangePhoneUnAuthed() async {
         do {
             PassageAPIClient.shared.appId = appInfoValid.id
-            let response = try await PassageAPIClient.shared
+            let _ = try await PassageAPIClient.shared
                 .changePhone(token: "", newPhone: "555-555-5555", magicLinkPath: nil, redirectUrl: nil, language: nil)
             XCTAssertTrue(false)
         } catch {

--- a/Tests/Integration/PassageAPIClient/ChangeContactTests.swift
+++ b/Tests/Integration/PassageAPIClient/ChangeContactTests.swift
@@ -1,15 +1,7 @@
-//
-//  File.swift
-//
-//
-//  Created by blayne bayer on 2/16/23.
-//
-
 import XCTest
 @testable import Passage
 
 final class ChangeContactTests: XCTestCase {
-    
     
     override func setUp() {
         super.setUp()
@@ -24,10 +16,10 @@ final class ChangeContactTests: XCTestCase {
     func testChangeEmail() async {
         // make sure we have an authToken.
         XCTAssertNotEqual(authToken, "")
-        
         do {
             PassageAPIClient.shared.appId = appInfoValid.id
-            let response = try await PassageAPIClient.shared.changeEmail(token: authToken, newEmail: "blayne.bayer+2@passage.id", magicLinkPath: nil, redirectUrl: nil, language: nil)
+            let response = try await PassageAPIClient.shared
+                .changeEmail(token: authToken, newEmail: "blayne.bayer+2@passage.id", magicLinkPath: nil, redirectUrl: nil, language: nil)
             XCTAssertNotNil(response.id)
         } catch {
             XCTAssertTrue(false)
@@ -37,16 +29,14 @@ final class ChangeContactTests: XCTestCase {
     func testChangeEmailUnAuthed() async {
         do {
             PassageAPIClient.shared.appId = appInfoValid.id
-            let response = try await PassageAPIClient.shared.changeEmail(token: "", newEmail: "blayne.bayer+2@passage.id", magicLinkPath: nil, redirectUrl: nil, language: nil)
-
+            let response = try await PassageAPIClient.shared
+                .changeEmail(token: "", newEmail: "blayne.bayer+2@passage.id", magicLinkPath: nil, redirectUrl: nil, language: nil)
             XCTAssertTrue(false)
         } catch {
-
             XCTAssertTrue(error is PassageAPIError)
-
             if let thrownError = error as? PassageAPIError {
                 switch thrownError {
-                    case .unauthorized(let response):
+                    case .unauthorized:
                         XCTAssertTrue(true)
                 default:
                     XCTAssertFalse(true)
@@ -58,10 +48,10 @@ final class ChangeContactTests: XCTestCase {
     func testChangePhone() async {
         // make sure we have an authToken.
         XCTAssertNotEqual(authToken, "")
-        
         do {
             PassageAPIClient.shared.appId = appInfoValid.id
-            let response = try await PassageAPIClient.shared.changePhone(token: authToken, newPhone: "+15125874725", magicLinkPath: nil, redirectUrl: nil, language: nil)
+            let response = try await PassageAPIClient.shared
+                .changePhone(token: authToken, newPhone: "+15125874725", magicLinkPath: nil, redirectUrl: nil, language: nil)
             XCTAssertNotNil(response.id)
         } catch {
             XCTAssertTrue(false)
@@ -71,17 +61,16 @@ final class ChangeContactTests: XCTestCase {
     func testChangePhoneInvalid() async {
         // make sure we have an authToken.
         XCTAssertNotEqual(authToken, "")
-        
         do {
             PassageAPIClient.shared.appId = appInfoValid.id
-            let response = try await PassageAPIClient.shared.changePhone(token: authToken, newPhone: "5125874725", magicLinkPath: nil, redirectUrl: nil, language: nil)
+            let response = try await PassageAPIClient.shared
+                .changePhone(token: authToken, newPhone: "5125874725", magicLinkPath: nil, redirectUrl: nil, language: nil)
             XCTAssertTrue(false)
         } catch {
             XCTAssertTrue(error is PassageAPIError)
-
             if let thrownError = error as? PassageAPIError {
                 switch thrownError {
-                    case .badRequest(let response):
+                    case .badRequest:
                         XCTAssertTrue(true)
                 default:
                     XCTAssertFalse(true)
@@ -94,16 +83,14 @@ final class ChangeContactTests: XCTestCase {
     func testChangePhoneUnAuthed() async {
         do {
             PassageAPIClient.shared.appId = appInfoValid.id
-            let response = try await PassageAPIClient.shared.changePhone(token: "", newPhone: "555-555-5555", magicLinkPath: nil, redirectUrl: nil, language: nil)
-
+            let response = try await PassageAPIClient.shared
+                .changePhone(token: "", newPhone: "555-555-5555", magicLinkPath: nil, redirectUrl: nil, language: nil)
             XCTAssertTrue(false)
         } catch {
-
             XCTAssertTrue(error is PassageAPIError)
-
             if let thrownError = error as? PassageAPIError {
                 switch thrownError {
-                    case .unauthorized(let response):
+                    case .unauthorized:
                         XCTAssertTrue(true)
                 default:
                     XCTAssertFalse(true)

--- a/Tests/Integration/PassageAPIClient/CurrentUserTests.swift
+++ b/Tests/Integration/PassageAPIClient/CurrentUserTests.swift
@@ -1,10 +1,3 @@
-//
-//  File.swift
-//
-//
-//  Created by blayne bayer on 2/15/23.
-//
-
 import XCTest
 @testable import Passage
 
@@ -22,32 +15,29 @@ final class CurrentUserTests: XCTestCase {
 
     
     func testCurrentUser() async {
-        
         // make sure we have an authToken.
         XCTAssertNotEqual(authToken, "")
-        
         do {
             PassageAPIClient.shared.appId = appInfoValid.id
             let response = try await PassageAPIClient.shared.currentUser(token: authToken)
             XCTAssertEqual(response.id, currentUser.id)
-            XCTAssertEqual(response.created_at, currentUser.created_at)
+            XCTAssertEqual(response.createdAt, currentUser.createdAt)
             XCTAssertEqual(response.status, currentUser.status)
             XCTAssertEqual(response.email, currentUser.email)
-            XCTAssertEqual(response.email_verified, currentUser.email_verified)
+            XCTAssertEqual(response.emailVerified, currentUser.emailVerified)
             XCTAssertEqual(response.phone, currentUser.phone)
-            XCTAssertEqual(response.phone_verified, currentUser.phone_verified)
+            XCTAssertEqual(response.phoneVerified, currentUser.phoneVerified)
             XCTAssertEqual(response.webauthn, currentUser.webauthn)
         } catch {
             // fail the test if we catch an error
             XCTAssertTrue(false)
         }
-        
     }
 
     func testCurrentUserNotAuthorized() async {
         do {
             PassageAPIClient.shared.appId = appInfoValid.id
-            let response = try await PassageAPIClient.shared.currentUser(token: "")
+            let _ = try await PassageAPIClient.shared.currentUser(token: "")
             // fail if we didn't get an error
             XCTAssertTrue(false)
         }
@@ -56,7 +46,7 @@ final class CurrentUserTests: XCTestCase {
             
             if let thrownError = error as? PassageAPIError {
                 switch thrownError {
-                    case .unauthorized(let response):
+                    case .unauthorized:
                         XCTAssertTrue(true)
                 default:
                     XCTAssertFalse(true)

--- a/Tests/Integration/PassageAPIClient/DeviceTests.swift
+++ b/Tests/Integration/PassageAPIClient/DeviceTests.swift
@@ -1,15 +1,7 @@
-//
-//  File.swift
-//  
-//
-//  Created by blayne bayer on 2/16/23.
-//
-
 import XCTest
 @testable import Passage
 
 final class ListDevicesTests: XCTestCase {
-    
     
     override func setUp() {
         super.setUp()
@@ -30,7 +22,7 @@ final class ListDevicesTests: XCTestCase {
             let response = try await PassageAPIClient.shared.listDevices(token: authToken)
             XCTAssertGreaterThan(response.count, 0)
             XCTAssertEqual(response.count, 2)
-            XCTAssertEqual(response[0].user_id,currentUser.id)
+            XCTAssertEqual(response[0].userId,currentUser.id)
         } catch {
             XCTAssertTrue(false)
         }
@@ -39,15 +31,13 @@ final class ListDevicesTests: XCTestCase {
     func testListDevicesUnAuthed() async {
         do {
             PassageAPIClient.shared.appId = appInfoValid.id
-            let response = try await PassageAPIClient.shared.listDevices(token: "")
+            let _ = try await PassageAPIClient.shared.listDevices(token: "")
             XCTAssertTrue(false)
         } catch {
-            
             XCTAssertTrue(error is PassageAPIError)
-            
             if let thrownError = error as? PassageAPIError {
                 switch thrownError {
-                    case .unauthorized(let response):
+                    case .unauthorized:
                         XCTAssertTrue(true)
                 default:
                     XCTAssertFalse(true)
@@ -60,11 +50,12 @@ final class ListDevicesTests: XCTestCase {
     func testAddDeviceStart() async {
         do {
             PassageAPIClient.shared.appId = appInfoValid.id
-            let response = try await PassageAPIClient.shared.addDeviceStart(token: authToken)
+            let _ = try await PassageAPIClient.shared.addDeviceStart(token: authToken)
             // ensure we got a response. Pretty much all we can test for now.
             // If the response changes it should throw a swiftdecode error, which would fail the test
             XCTAssertTrue(true)
         } catch {
+            print(error)
             XCTAssertTrue(false)
         }
     }
@@ -73,15 +64,13 @@ final class ListDevicesTests: XCTestCase {
     func testAddDeviceStartUnAuthed() async {
         do {
             PassageAPIClient.shared.appId = appInfoValid.id
-            let response = try await PassageAPIClient.shared.addDeviceStart(token: "")
+            let _ = try await PassageAPIClient.shared.addDeviceStart(token: "")
             XCTAssertTrue(false)
         } catch {
-            
             XCTAssertTrue(error is PassageAPIError)
-            
             if let thrownError = error as? PassageAPIError {
                 switch thrownError {
-                    case .unauthorized(let response):
+                    case .unauthorized:
                         XCTAssertTrue(true)
                 default:
                     XCTAssertFalse(true)
@@ -95,7 +84,8 @@ final class ListDevicesTests: XCTestCase {
         do {
             PassageAPIClient.shared.appId = appInfoValid.id
             let listDevicesResponse = try await PassageAPIClient.shared.listDevices(token: authToken)
-            let response = try await PassageAPIClient.shared.updateDevice(token: authToken, deviceId: listDevicesResponse[0].id, friendlyName: "integration test device" )
+            let _ = try await PassageAPIClient.shared
+                .updateDevice(token: authToken, deviceId: listDevicesResponse[0].id, friendlyName: "integration test device" )
             // ensure we got a response. Pretty much all we can test for now.
             // If the response changes it should throw a swiftdecode error, which would fail the test
             XCTAssertTrue(true)

--- a/Tests/Integration/PassageAPIClient/GetUserTests.swift
+++ b/Tests/Integration/PassageAPIClient/GetUserTests.swift
@@ -1,10 +1,3 @@
-//
-//  File.swift
-//  
-//
-//  Created by blayne bayer on 2/15/23.
-//
-
 import XCTest
 @testable import Passage
 
@@ -23,16 +16,14 @@ final class GetUserTests: XCTestCase {
     func testUserFound() async {
         do {
             PassageAPIClient.shared.appId = appInfoValid.id
-            let response = try await PassageAPIClient.shared.getUser(identifier: registeredUser.email ?? "")
+            let response = try await PassageAPIClient.shared.getUser(identifier: registeredUser.email)
             XCTAssertEqual(response.id, currentUser.id)
             XCTAssertEqual(response.status, currentUser.status)
             XCTAssertEqual(response.email, currentUser.email)
-            XCTAssertEqual(response.email_verified, currentUser.email_verified)
+            XCTAssertEqual(response.emailVerified, currentUser.emailVerified)
             XCTAssertEqual(response.phone, currentUser.phone)
-            XCTAssertEqual(response.phone_verified, currentUser.phone_verified)
+            XCTAssertEqual(response.phoneVerified, currentUser.phoneVerified)
             XCTAssertEqual(response.webauthn, currentUser.webauthn)
-
-            
         } catch {
             XCTAssertTrue(false)
         }
@@ -41,12 +32,12 @@ final class GetUserTests: XCTestCase {
     func testUserNotFound() async {
         do {
             PassageAPIClient.shared.appId = appInfoValid.id
-            let response = try await PassageAPIClient.shared.getUser(identifier: unregisteredUserEmail)
+            let _ = try await PassageAPIClient.shared.getUser(identifier: unregisteredUserEmail)
             XCTAssertFalse(true)
         }
         catch  {
             XCTAssertTrue(true)
         }
-        
     }
+    
 }

--- a/Tests/Integration/PassageAPIClient/GetUserTests.swift
+++ b/Tests/Integration/PassageAPIClient/GetUserTests.swift
@@ -16,7 +16,7 @@ final class GetUserTests: XCTestCase {
     func testUserFound() async {
         do {
             PassageAPIClient.shared.appId = appInfoValid.id
-            let response = try await PassageAPIClient.shared.getUser(identifier: registeredUser.email)
+            let response = try await PassageAPIClient.shared.getUser(identifier: registeredUser.email ?? "")
             XCTAssertEqual(response.id, currentUser.id)
             XCTAssertEqual(response.status, currentUser.status)
             XCTAssertEqual(response.email, currentUser.email)

--- a/Tests/Integration/PassageAPIClient/MagicLinkTests.swift
+++ b/Tests/Integration/PassageAPIClient/MagicLinkTests.swift
@@ -36,7 +36,7 @@ final class MagicLinkTests: XCTestCase {
         do {
             PassageAPIClient.shared.appId = appInfoValid.id
             let response = try await PassageAPIClient.shared
-                .sendLoginMagicLink(identifier: registeredUser.email, path: nil, language: nil)
+                .sendLoginMagicLink(identifier: registeredUser.email ?? "", path: nil, language: nil)
             do {
                 _ = try await PassageAPIClient.shared.magicLinkStatus(id: response.id)
                 XCTAssertTrue(false) // the status should error as it is unactivated

--- a/Tests/Integration/PassageAPIClient/MagicLinkTests.swift
+++ b/Tests/Integration/PassageAPIClient/MagicLinkTests.swift
@@ -24,7 +24,7 @@ final class MagicLinkTests: XCTestCase {
         do {
             PassageAPIClient.shared.appId = appInfoValid.id
             let date = Date().timeIntervalSince1970
-            let identifier = "authentigator" + "+" + String(date) + "@passage.id"
+            let identifier = "authentigator+\(date)@passage.id"
             let response = try await PassageAPIClient.shared.sendRegisterMagicLink(identifier: identifier, path: nil, language: nil)
             do {
                 _ = try await PassageAPIClient.shared.magicLinkStatus(id: response.id)
@@ -55,10 +55,10 @@ final class MagicLinkTests: XCTestCase {
     }
     
     func testActivateMagicLink() async {
-        do{
+        do {
             PassageAPIClient.shared.appId = appInfoValid.id
             let date = Date().timeIntervalSince1970
-            let identifier = "authentigator" + "+" + String(date) + "@ncor7c1m.mailosaur.net"
+            let identifier = "authentigator+\(date)@\(MailosaurAPIClient.serverId).mailosaur.net"
             let response = try await PassageAPIClient.shared.sendRegisterMagicLink(identifier: identifier, path: nil, language: nil)
             try await Task.sleep(nanoseconds: UInt64(3 * Double(NSEC_PER_SEC)))
             let magicLink = try await MailosaurAPIClient().getMostRecentMagicLink()
@@ -72,6 +72,7 @@ final class MagicLinkTests: XCTestCase {
             }
         } catch {
             print(error)
+            XCTAssertTrue(false)
         }
     }
 }

--- a/Tests/Integration/PassageAPIClient/MagicLinkTests.swift
+++ b/Tests/Integration/PassageAPIClient/MagicLinkTests.swift
@@ -1,9 +1,3 @@
-//
-//  MagicLinkTests.swift
-//  
-//
-//  Created by Kevin Flanagan on 2/16/23.
-//
 import XCTest
 @testable import Passage
 
@@ -25,14 +19,14 @@ final class MagicLinkTests: XCTestCase {
             PassageAPIClient.shared.appId = appInfoValid.id
             let date = Date().timeIntervalSince1970
             let identifier = "authentigator+\(date)@passage.id"
-            let response = try await PassageAPIClient.shared.sendRegisterMagicLink(identifier: identifier, path: nil, language: nil)
+            let response = try await PassageAPIClient.shared
+                .sendRegisterMagicLink(identifier: identifier, path: nil, language: nil)
             do {
                 _ = try await PassageAPIClient.shared.magicLinkStatus(id: response.id)
                 XCTAssertTrue(false) // the status should error as it is unactivated
             } catch {
                 XCTAssertTrue(true)
             }
-            
         } catch {
             XCTAssertTrue(false)
         }
@@ -41,7 +35,8 @@ final class MagicLinkTests: XCTestCase {
     func testSendLoginMagicLink() async {
         do {
             PassageAPIClient.shared.appId = appInfoValid.id
-            let response = try await PassageAPIClient.shared.sendLoginMagicLink(identifier: registeredUser.email!, path: nil, language: nil)
+            let response = try await PassageAPIClient.shared
+                .sendLoginMagicLink(identifier: registeredUser.email, path: nil, language: nil)
             do {
                 _ = try await PassageAPIClient.shared.magicLinkStatus(id: response.id)
                 XCTAssertTrue(false) // the status should error as it is unactivated
@@ -59,7 +54,8 @@ final class MagicLinkTests: XCTestCase {
             PassageAPIClient.shared.appId = appInfoValid.id
             let date = Date().timeIntervalSince1970
             let identifier = "authentigator+\(date)@\(MailosaurAPIClient.serverId).mailosaur.net"
-            let response = try await PassageAPIClient.shared.sendRegisterMagicLink(identifier: identifier, path: nil, language: nil)
+            let response = try await PassageAPIClient.shared
+                .sendRegisterMagicLink(identifier: identifier, path: nil, language: nil)
             try await Task.sleep(nanoseconds: UInt64(3 * Double(NSEC_PER_SEC)))
             let magicLink = try await MailosaurAPIClient().getMostRecentMagicLink()
             let token = try await PassageAPIClient.shared.activateMagicLink(magicLink: magicLink)

--- a/Tests/Integration/PassageAPIClient/OneTimePasscodeTests.swift
+++ b/Tests/Integration/PassageAPIClient/OneTimePasscodeTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+@testable import Passage
+
+final class OneTimePasscodeTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        PassageSettings.shared.apiUrl = apiUrl
+        PassageSettings.shared.appId = otpAppInfoValid.id
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    @available(iOS 15.0, *)
+    func testSendRegisterOneTimePasscode() async {
+        do {
+            PassageAPIClient.shared.appId = otpAppInfoValid.id
+            let date = Date().timeIntervalSince1970
+            let identifier = "authentigator+\(date)@passage.id"
+            let _ = try await PassageAPIClient.shared.sendRegisterOneTimePasscode(identifier: identifier, language: nil)
+            XCTAssertTrue(true)
+        } catch {
+            XCTAssertTrue(false)
+        }
+    }
+    
+    func testSendLoginOneTimePasscode() async {
+        do {
+            PassageAPIClient.shared.appId = otpAppInfoValid.id
+            let _ = try await PassageAPIClient.shared.sendLoginOneTimePasscode(identifier: otpRegisteredUser.email!, language: nil)
+            XCTAssertTrue(true)
+        } catch {
+            XCTAssertTrue(false)
+        }
+    }
+    
+    func testActivateOneTimePasscode() async {
+        do {
+            PassageAPIClient.shared.appId = otpAppInfoValid.id
+            let date = Date().timeIntervalSince1970
+            let identifier = "authentigator+\(date)@\(MailosaurAPIClient.serverId).mailosaur.net"
+            let response = try await PassageAPIClient.shared.sendRegisterOneTimePasscode(identifier: identifier, language: nil)
+            try await Task.sleep(nanoseconds: UInt64(3 * Double(NSEC_PER_SEC)))
+            let oneTimePasscode = try await MailosaurAPIClient().getMostRecentOneTimePasscode()
+            let token = try await PassageAPIClient.shared.activateOneTimePasscode(otp: oneTimePasscode, otpId: response.id)
+            XCTAssertNotNil(token)
+        } catch {
+            print(error)
+            XCTAssertTrue(false)
+        }
+    }
+}

--- a/Tests/Integration/PassageAPIClient/OneTimePasscodeTests.swift
+++ b/Tests/Integration/PassageAPIClient/OneTimePasscodeTests.swift
@@ -31,7 +31,7 @@ final class OneTimePasscodeTests: XCTestCase {
         do {
             PassageAPIClient.shared.appId = otpAppInfoValid.id
             let _ = try await PassageAPIClient.shared
-                .sendLoginOneTimePasscode(identifier: otpRegisteredUser.email, language: nil)
+                .sendLoginOneTimePasscode(identifier: otpRegisteredUser.email ?? "", language: nil)
             XCTAssertTrue(true)
         } catch {
             XCTAssertTrue(false)

--- a/Tests/Integration/PassageAPIClient/OneTimePasscodeTests.swift
+++ b/Tests/Integration/PassageAPIClient/OneTimePasscodeTests.swift
@@ -19,7 +19,8 @@ final class OneTimePasscodeTests: XCTestCase {
             PassageAPIClient.shared.appId = otpAppInfoValid.id
             let date = Date().timeIntervalSince1970
             let identifier = "authentigator+\(date)@passage.id"
-            let _ = try await PassageAPIClient.shared.sendRegisterOneTimePasscode(identifier: identifier, language: nil)
+            let _ = try await PassageAPIClient.shared
+                .sendRegisterOneTimePasscode(identifier: identifier, language: nil)
             XCTAssertTrue(true)
         } catch {
             XCTAssertTrue(false)
@@ -29,7 +30,8 @@ final class OneTimePasscodeTests: XCTestCase {
     func testSendLoginOneTimePasscode() async {
         do {
             PassageAPIClient.shared.appId = otpAppInfoValid.id
-            let _ = try await PassageAPIClient.shared.sendLoginOneTimePasscode(identifier: otpRegisteredUser.email!, language: nil)
+            let _ = try await PassageAPIClient.shared
+                .sendLoginOneTimePasscode(identifier: otpRegisteredUser.email, language: nil)
             XCTAssertTrue(true)
         } catch {
             XCTAssertTrue(false)
@@ -41,7 +43,8 @@ final class OneTimePasscodeTests: XCTestCase {
             PassageAPIClient.shared.appId = otpAppInfoValid.id
             let date = Date().timeIntervalSince1970
             let identifier = "authentigator+\(date)@\(MailosaurAPIClient.serverId).mailosaur.net"
-            let response = try await PassageAPIClient.shared.sendRegisterOneTimePasscode(identifier: identifier, language: nil)
+            let response = try await PassageAPIClient.shared
+                .sendRegisterOneTimePasscode(identifier: identifier, language: nil)
             try await Task.sleep(nanoseconds: UInt64(3 * Double(NSEC_PER_SEC)))
             let oneTimePasscode = try await MailosaurAPIClient().getMostRecentOneTimePasscode()
             let token = try await PassageAPIClient.shared.activateOneTimePasscode(otp: oneTimePasscode, otpId: response.id)

--- a/Tests/Integration/PassageAPIClient/SessionTests.swift
+++ b/Tests/Integration/PassageAPIClient/SessionTests.swift
@@ -25,7 +25,7 @@ final class SessionTests: XCTestCase {
             // Sign in and get tokens
             PassageAPIClient.shared.appId = appInfoRefreshToken.id
             let date = Date().timeIntervalSince1970
-            let identifier = "authentigator" + "+" + String(date) + "@ncor7c1m.mailosaur.net"
+            let identifier = "authentigator+\(date)@\(MailosaurAPIClient.serverId).mailosaur.net"
             _ = try await PassageAPIClient.shared.sendRegisterMagicLink(identifier: identifier, path: nil, language: nil)
             try await Task.sleep(nanoseconds: UInt64(3 * Double(NSEC_PER_SEC)))
             let magicLink = try await MailosaurAPIClient().getMostRecentMagicLink()
@@ -40,7 +40,7 @@ final class SessionTests: XCTestCase {
             
             // Sign out the session
             try await PassageAPIClient.shared.signOut(refreshToken: newTokens.refresh_token!)
-            try await Task.sleep(nanoseconds: UInt64(Double(appInfoRefreshToken.session_timeout_length) * Double(NSEC_PER_SEC)))
+            try await Task.sleep(nanoseconds: UInt64(Double(appInfoRefreshToken.sessionTimeoutLength) * Double(NSEC_PER_SEC)))
             do {
                 _ = try await PassageAPIClient.shared.currentUser(token: newTokens.auth_token!)
                 XCTAssertTrue(false) // the above function should throw an unauthenticated exception

--- a/Tests/Integration/PassageAPIClient/WebauthnLoginStartTests.swift
+++ b/Tests/Integration/PassageAPIClient/WebauthnLoginStartTests.swift
@@ -17,7 +17,7 @@ final class WebauthnLoginStartTests: XCTestCase {
     func testWebauthnLoginStart() async {
         do {
             PassageAPIClient.shared.appId = appInfoValid.id
-            let response = try await PassageAPIClient.shared.webauthnLoginStart()
+            let _ = try await PassageAPIClient.shared.webauthnLoginStart()
             // ensure we got a response. Pretty much all we can test for now.
             // If the response changes it should throw a swiftdecode error, which would fail the test
             XCTAssertTrue(true)

--- a/Tests/Integration/PassageAPIClient/WebauthnLoginStartTests.swift
+++ b/Tests/Integration/PassageAPIClient/WebauthnLoginStartTests.swift
@@ -1,10 +1,3 @@
-//
-//  File.swift
-//
-//
-//  Created by blayne bayer on 2/15/23.
-//
-
 import XCTest
 @testable import Passage
 

--- a/Tests/PassageTests/MockPassageAPIClient.swift
+++ b/Tests/PassageTests/MockPassageAPIClient.swift
@@ -40,7 +40,7 @@ final class MockPassageAPIClient: PassageAuthAPIClient {
     
     @available(iOS 16.0, *)
     func webauthnRegistrationFinish(startResponse: Passage.WebauthnRegisterStartResponse, params: ASAuthorizationPlatformPublicKeyCredentialRegistration?) async throws -> Passage.AuthResult {
-        return AuthResult(auth_token: "TEST_TOKEN", redirect_url: nil)
+        return AuthResult(authToken: "TEST_TOKEN", redirectURL: "/", refreshToken: nil, refreshTokenExpiration: nil)
     }
     
     @available(iOS 16.0, *)
@@ -93,7 +93,7 @@ final class MockPassageAPIClient: PassageAuthAPIClient {
         throw PassageError.unknown
     }
     
-    func currentUser(token: String) async throws -> Passage.PassageUserDetails {
+    func currentUser(token: String) async throws -> Passage.PassageUserInfo {
         throw PassageError.unknown
     }
     
@@ -117,15 +117,34 @@ final class MockPassageAPIClient: PassageAuthAPIClient {
         throw PassageError.unknown
     }
     
-    func getUser(identifier: String) async throws -> Passage.PassageUser {
+    func getUser(identifier: String) async throws -> Passage.PassageUserInfo {
         guard identifier == "registered-test-user@passage.id" else {
             throw PassageError.userDoesNotExist
         }
-        return PassageUser(id: "TEST_ID", email_verified: true, phone_verified: true, webauthn: true)
+        return PassageUserInfo(
+            createdAt: "",
+            email: "",
+            emailVerified: true,
+            id: "",
+            lastLoginAt: "",
+            loginCount: 1,
+            phone: "",
+            phoneVerified: true,
+            status: "",
+            updatedAt: "",
+            webauthn: true,
+            webauthnDevices: [],
+            webauthnTypes: []
+        )
     }
     
     func refresh(refreshToken: String) async throws -> AuthResult {
-        return AuthResult(auth_token: "TEST_TOKEN", refresh_token: "TEST_REFRESH_TOKEN", redirect_url: "")
+        return AuthResult(
+            authToken: "TEST_TOKEN",
+            redirectURL: "/",
+            refreshToken: "TEST_REFRESH_TOKEN",
+            refreshTokenExpiration: 6000
+        )
     }
     
     func signOut(refreshToken: String) async throws {

--- a/Tests/PassageTests/MockPassageAPIClient.swift
+++ b/Tests/PassageTests/MockPassageAPIClient.swift
@@ -32,7 +32,7 @@ final class MockPassageAPIClient: PassageAuthAPIClient {
     
     @available(iOS 16.0, *)
     func webauthnRegistrationStart(identifier: String) async throws -> Passage.WebauthnRegisterStartResponse {
-        guard identifier == "unregistered-test-user@passage.id" else {
+        guard identifier == unregisteredUserEmail else {
             throw PassageError.userAlreadyExists
         }
         return testRegisterStartResponse
@@ -54,14 +54,14 @@ final class MockPassageAPIClient: PassageAuthAPIClient {
     }
     
     func sendLoginMagicLink(identifier: String, path: String?, language: String? = nil) async throws -> Passage.MagicLink {
-        guard identifier == "registered-test-user@passage.id" else {
+        guard identifier == registeredUserEmail else {
             throw PassageError.unknown
         }
         return Passage.MagicLink(id: "TEST_MAGIC_LINK")
     }
     
     func sendRegisterMagicLink(identifier: String, path: String?, language: String? = nil) async throws -> Passage.MagicLink {
-        guard identifier == "unregistered-test-user@passage.id" else {
+        guard identifier == unregisteredUserEmail else {
             throw PassageError.userAlreadyExists
         }
         return Passage.MagicLink(id: "TEST_MAGIC_LINK")
@@ -76,14 +76,14 @@ final class MockPassageAPIClient: PassageAuthAPIClient {
     }
     
     func sendLoginOneTimePasscode(identifier: String, language: String?) async throws -> Passage.OneTimePasscode {
-        guard identifier == "registered-test-user@passage.id" else {
+        guard identifier == registeredUserEmail else {
             throw PassageError.unknown
         }
         return Passage.OneTimePasscode(id: "TEST_ONE_TIME_PASSCODE")
     }
     
     func sendRegisterOneTimePasscode(identifier: String, language: String?) async throws -> Passage.OneTimePasscode {
-        guard identifier == "unregistered-test-user@passage.id" else {
+        guard identifier == unregisteredUserEmail else {
             throw PassageError.userAlreadyExists
         }
         return Passage.OneTimePasscode(id: "TEST_ONE_TIME_PASSCODE")
@@ -118,7 +118,7 @@ final class MockPassageAPIClient: PassageAuthAPIClient {
     }
     
     func getUser(identifier: String) async throws -> Passage.PassageUserInfo {
-        guard identifier == "registered-test-user@passage.id" else {
+        guard identifier == registeredUserEmail else {
             throw PassageError.userDoesNotExist
         }
         return PassageUserInfo(

--- a/Tests/PassageTests/MockPassageAPIClient.swift
+++ b/Tests/PassageTests/MockPassageAPIClient.swift
@@ -75,6 +75,24 @@ final class MockPassageAPIClient: PassageAuthAPIClient {
         throw PassageError.unknown
     }
     
+    func sendLoginOneTimePasscode(identifier: String, language: String?) async throws -> Passage.OneTimePasscode {
+        guard identifier == "registered-test-user@passage.id" else {
+            throw PassageError.unknown
+        }
+        return Passage.OneTimePasscode(id: "TEST_ONE_TIME_PASSCODE")
+    }
+    
+    func sendRegisterOneTimePasscode(identifier: String, language: String?) async throws -> Passage.OneTimePasscode {
+        guard identifier == "unregistered-test-user@passage.id" else {
+            throw PassageError.userAlreadyExists
+        }
+        return Passage.OneTimePasscode(id: "TEST_ONE_TIME_PASSCODE")
+    }
+    
+    func activateOneTimePasscode(otp: String, otpId: String) async throws -> Passage.AuthResult {
+        throw PassageError.unknown
+    }
+    
     func currentUser(token: String) async throws -> Passage.PassageUserDetails {
         throw PassageError.unknown
     }

--- a/Tests/PassageTests/PassageAuthStaticTestData.swift
+++ b/Tests/PassageTests/PassageAuthStaticTestData.swift
@@ -30,16 +30,33 @@ let testLoginStartResponse = WebauthnLoginStartResponse(
                 rpId: "TEST_RPID"
             )
         )
-    )
+    ),
+    user: nil
 )
 
 let testLoginFinishResponse = AuthResult(
-    auth_token: "TEST_TOKEN",
-    redirect_url: nil
+    authToken: "TEST_TOKEN",
+    redirectURL: "/",
+    refreshToken: nil,
+    refreshTokenExpiration: nil
 )
 
 let testRegisterStartResponse = WebauthnRegisterStartResponse(
-    user: PassageUser(id: "TEST_ID", email_verified: true, phone_verified: true, webauthn: true),
+    user: PassageUserInfo(
+        createdAt: "",
+        email: "",
+        emailVerified: true,
+        id: "",
+        lastLoginAt: "",
+        loginCount: 1,
+        phone: "",
+        phoneVerified: true,
+        status: "",
+        updatedAt: "",
+        webauthn: true,
+        webauthnDevices: [],
+        webauthnTypes: []
+    ),
     handshake: WebauthnRegisterStartResponseHandshake(
         id: "TEST_ID",
         challenge: WebauthnRegisterStartResponseHandshakeChallenge(

--- a/Tests/PassageTests/PassageAuthStaticTestData.swift
+++ b/Tests/PassageTests/PassageAuthStaticTestData.swift
@@ -5,18 +5,19 @@ let unregisteredUserEmail = "unregistered-test-user@passage.id"
 let registeredUserEmail = "registered-test-user@passage.id"
 
 let testAppInfo = AppInfo(
-    id: "TEST_APP_ID",
+    allowedIdentifier: "TEST_ALLOWED_IDENTIFIER",
+    authFallbackMethodString: "magic_link",
+    authOrigin: "TEST_AUTH_ORIGIN",
     ephemeral: true,
+    id: "TEST_APP_ID",
+    loginURL: "TEST_LOGIN_URL",
     name: "TEST_APP",
-    redirect_url: "TEST_APP_URL",
-    login_url: "TEST_LOGIN_URL",
-    allowed_identifier: "TEST_ALLOWED_IDENTIFIER",
-    required_identifier: "TEST_REQUIRED_IDENTIFIER",
-    auth_origin: "TEST_AUTH_ORIGIN",
-    require_email_verification: false,
-    require_identifier_verification: false,
-    session_timeout_length: 6000,
-    public_signup: true
+    publicSignup: true,
+    redirectURL: "TEST_APP_URL",
+    requiredIdentifier: "TEST_REQUIRED_IDENTIFIER",
+    requireEmailVerification: false,
+    requireIdentifierVerification: false,
+    sessionTimeoutLength: 6000
 )
 
 let testLoginStartResponse = WebauthnLoginStartResponse(

--- a/Tests/PassageTests/PassageAuthStaticTests.swift
+++ b/Tests/PassageTests/PassageAuthStaticTests.swift
@@ -6,7 +6,7 @@ final class PassageAuthStaticTests: XCTestCase {
     override func setUp() {
         super.setUp()
         PassageSettings.shared.appId = testAppInfo.id
-        PassageSettings.shared.authOrigin = testAppInfo.auth_origin
+        PassageSettings.shared.authOrigin = testAppInfo.authOrigin
         PassageSettings.shared.apiUrl = "TEST_API_URL"
         PassageAPIClient.shared = MockPassageAPIClient()
         if #available(iOS 16.0, *) {
@@ -44,7 +44,7 @@ final class PassageAuthStaticTests: XCTestCase {
         if #available(iOS 16.0, *) {
             XCTAssertTrue(result?.authResult is AuthResult)
         } else {
-            XCTAssertTrue(result?.magicLink is MagicLink)
+            XCTAssertTrue(result?.authFallbackResult is AuthFallbackResult)
         }
     }
     
@@ -53,7 +53,7 @@ final class PassageAuthStaticTests: XCTestCase {
         if #available(iOS 16.0, *) {
             XCTAssertTrue(result?.authResult is AuthResult)
         } else {
-            XCTAssertTrue(result?.magicLink is MagicLink)
+            XCTAssertTrue(result?.authFallbackResult is AuthFallbackResult)
         }
     }
     


### PR DESCRIPTION
## ✨ New features

### One Time Passcodes

Your users can now login/register with one time passcodes as a fallback method when passkey login/registration is not available. Previously Magic Links were the only fallback option.

### No fallback

You can now force users to login or register with a passkey ONLY. Note that iOS users below iOS 16 will not be able to login or register to your app if that is your selection. 



## 🔁 Changes

- Replaced snake cased property names with camel case.
- Login and Register methods now fallback to Magic Links OR One Time Passcodes, depending on your Passage App settings.
- If you’ve disabled all fallbacks and your user does not or cannot use passkeys, a `PassageError.authFallbacksNotSupported` error will be thrown