### PR TITLE
User method updates. New optional language setting.

### DIFF
--- a/Sources/Passage/PassageAPIClient/PassageAPIClient.swift
+++ b/Sources/Passage/PassageAPIClient/PassageAPIClient.swift
@@ -285,7 +285,7 @@ internal class PassageAPIClient : PassageAuthAPIClient {
     /// - Returns: ``Void``
     /// - Throws: ``PassageAPIError``
     @available(iOS 16.0, *)
-    internal func addDeviceFinish(token: String, startResponse: WebauthnRegisterStartResponse, params: ASAuthorizationPlatformPublicKeyCredentialRegistration) async throws -> Void {
+    internal func addDeviceFinish(token: String, startResponse: WebauthnRegisterStartResponse, params: ASAuthorizationPlatformPublicKeyCredentialRegistration) async throws -> DeviceInfo {
         let url = try self.appUrl(path: "currentuser/devices/finish/")
         
         let request = buildAuthenticatedRequest(url: url, method: "POST", token: token)
@@ -315,7 +315,8 @@ internal class PassageAPIClient : PassageAuthAPIClient {
         let (responseData, resp) = try await URLSession.shared.upload(for: request, from: data)
         
         try assertValidResponse(response: resp, responseData: responseData)
-        
+        let addDeviceResponse = try JSONDecoder().decode(WebauthnAddDeviceFinishResponse.self, from: responseData)
+        return addDeviceResponse.device
     }
     
     /// Send a new login magic link to the user's email or phone

--- a/Sources/Passage/PassageAPIClient/PassageAPIClient.swift
+++ b/Sources/Passage/PassageAPIClient/PassageAPIClient.swift
@@ -28,6 +28,10 @@ internal class PassageAPIClient : PassageAuthAPIClient {
     /// This should be set in the Passage.plist file or it will default to the production url
     internal var baseUrl: String?
     
+    /// The language messages to user should be sent in.
+    ///
+    /// This can be configured in the Passage.plist file.
+    internal var language: String?
     
     /// Private initializer
     ///
@@ -37,6 +41,7 @@ internal class PassageAPIClient : PassageAuthAPIClient {
     private init() {
         self.appId = PassageSettings.shared.appId!
         self.baseUrl = PassageSettings.shared.apiUrl ?? "https://auth.passage.id"
+        self.language = PassageSettings.shared.language
     }
 
     /// Get the configured Passage Application details.
@@ -330,7 +335,7 @@ internal class PassageAPIClient : PassageAuthAPIClient {
         let params = [
             "identifier": identifier,
             "path": path,
-            "language": language
+            "language": language ?? self.language
         ]
         let responseData = try await sendRequest(path: "login/magic-link/", method: .post, params: params)
         let sendMagicLinkResponse = try JSONDecoder().decode(SendMagicLinkResponse.self, from: responseData)
@@ -348,7 +353,7 @@ internal class PassageAPIClient : PassageAuthAPIClient {
         let params = [
             "identifier": identifier,
             "path": path,
-            "language": language
+            "language": language ?? self.language
         ]
         let responseData = try await sendRequest(path: "register/magic-link/", method: .post, params: params)
         let sendMagicLinkResponse = try JSONDecoder().decode(SendMagicLinkResponse.self, from: responseData)
@@ -386,7 +391,7 @@ internal class PassageAPIClient : PassageAuthAPIClient {
     func sendLoginOneTimePasscode(identifier: String, language: String?) async throws -> OneTimePasscode {
         let params = [
             "identifier": identifier,
-            "language": language
+            "language": language ?? self.language
         ]
         let responseData = try await sendRequest(path: "login/otp", method: .post, params: params)
         let oneTimePasscode = try JSONDecoder().decode(OneTimePasscode.self, from: responseData)
@@ -402,7 +407,7 @@ internal class PassageAPIClient : PassageAuthAPIClient {
     func sendRegisterOneTimePasscode(identifier: String, language: String?) async throws -> OneTimePasscode {
         let params = [
             "identifier": identifier,
-            "language": language
+            "language": language ?? self.language
         ]
         let responseData = try await sendRequest(path: "register/otp", method: .post, params: params)
         let oneTimePasscode = try JSONDecoder().decode(OneTimePasscode.self, from: responseData)
@@ -485,9 +490,7 @@ internal class PassageAPIClient : PassageAuthAPIClient {
         if (magicLinkPath != nil) {
             jsonObject["magic_link_path"] = magicLinkPath
         }
-        if(language != nil) {
-            jsonObject["language"] = language
-        }
+        jsonObject["language"] = language ?? self.language
         let data = try JSONSerialization.data(withJSONObject: jsonObject, options: [])
         
         let (responseData, response) = try await URLSession.shared.upload(for: request, from: data)
@@ -510,30 +513,20 @@ internal class PassageAPIClient : PassageAuthAPIClient {
     /// - Returns: ``MagicLink``
     /// - Throws: ``PassageAPIError``
     internal func changePhone(token: String, newPhone: String, magicLinkPath: String?, redirectUrl: String?, language: String?) async throws -> MagicLink {
-        
-      let url = try self.appUrl(path: "currentuser/phone/")
-    
-      let request = buildAuthenticatedRequest(url: url, method: "PATCH", token: token)
-        
-      var jsonObject = ["new_phone": newPhone]
-        
-      if (redirectUrl != nil) {
+        let url = try self.appUrl(path: "currentuser/phone/")
+        let request = buildAuthenticatedRequest(url: url, method: "PATCH", token: token)
+        var jsonObject = ["new_phone": newPhone]
+        if (redirectUrl != nil) {
           jsonObject["redirect_url"] = redirectUrl
-      }
-      if (magicLinkPath != nil) {
+        }
+        if (magicLinkPath != nil) {
           jsonObject["magic_link_path"] = magicLinkPath
-      }
-      if(language != nil) {
-          jsonObject["language"] = language
-      }
-      let data = try JSONSerialization.data(withJSONObject: jsonObject, options: [])
-      
-      let (responseData, response) = try await URLSession.shared.upload(for: request, from: data)
-      
+        }
+        jsonObject["language"] = language ?? self.language
+        let data = try JSONSerialization.data(withJSONObject: jsonObject, options: [])
+        let (responseData, response) = try await URLSession.shared.upload(for: request, from: data)
         try assertValidResponse(response: response, responseData: responseData)
-      
-      let changePhoneResponse = try JSONDecoder().decode(ChangePhoneResponse.self, from: responseData)
-          
+        let changePhoneResponse = try JSONDecoder().decode(ChangePhoneResponse.self, from: responseData)
         return changePhoneResponse.magicLink
     }
     

--- a/Sources/Passage/PassageAPIClient/PassageAPIClientModels.swift
+++ b/Sources/Passage/PassageAPIClient/PassageAPIClientModels.swift
@@ -101,7 +101,7 @@ internal struct WebauthnRegisterStartResponse: Codable {
 /// API Response from webauthn registration finish
 internal typealias WebauthnRegisterFinishResponse = AuthResultResponse
 
-internal typealias WebauthnAddDeviceFinishResponse = AuthResultResponse
+internal typealias WebauthnAddDeviceFinishResponse = UpdateDeviceResponse
 
 internal typealias SendMagicLinkResponse = MagicLinkResponse
 

--- a/Sources/Passage/PassageAPIClient/PassageAPIClientProtocol.swift
+++ b/Sources/Passage/PassageAPIClient/PassageAPIClientProtocol.swift
@@ -81,7 +81,7 @@ protocol PassageAuthAPIClient  {
     ///   - params: The ASAuthorizationPlatformPublicKeyCredentialRegistration
     /// - Returns: ``Void``
     @available(iOS 16.0, *)
-    func addDeviceFinish(token: String, startResponse: WebauthnRegisterStartResponse,  params: ASAuthorizationPlatformPublicKeyCredentialRegistration) async throws -> Void
+    func addDeviceFinish(token: String, startResponse: WebauthnRegisterStartResponse,  params: ASAuthorizationPlatformPublicKeyCredentialRegistration) async throws -> DeviceInfo
     
     
     /// Send a new login magic link to the user's email or phone

--- a/Sources/Passage/PassageAuth.swift
+++ b/Sources/Passage/PassageAuth.swift
@@ -348,14 +348,12 @@ public class PassageAuth {
     ///
     /// Auth Token from the instance tokenStore will be used.
     ///
-    /// Still some issues to work out with Passkeys, so this is private for now.
-    ///
     /// - Parameters:
     ///   - newEmail: string - valid email address
     ///   - language: optional language string for localizing emails, if no lanuage or an invalid language is provided the application default lanuage will be used
     /// - Returns: ``MagicLink``
     /// - Throws: ``PassageAPIError``, ``PassageError``
-    private func changeEmail(newEmail: String, language: String? = nil) async throws -> MagicLink? {
+    public func changeEmail(newEmail: String, language: String? = nil) async throws -> MagicLink? {
         guard let token = self.tokenStore.authToken else {
             throw PassageError.unauthorized
         }
@@ -367,14 +365,12 @@ public class PassageAuth {
     ///
     /// Auth Token from the instance tokenStore will be used.
     ///
-    /// Still some issues to work out with Passkeys, so this is private for now.
-    ///
     /// - Parameters:
     ///   - newPhone: string - valid E164 formatted phone number.
     ///   - language: optional language string for localizing emails, if no lanuage or an invalid language is provided the application default lanuage will be used
     /// - Returns: ``MagicLink``
     /// - Throws: ``PassageAPIError``, ``PassageError``
-    private  func changePhone(newPhone: String, language: String? = nil) async throws -> MagicLink? {
+    public func changePhone(newPhone: String, language: String? = nil) async throws -> MagicLink? {
         guard let token = self.tokenStore.authToken else {
             throw PassageError.unauthorized
         }
@@ -977,33 +973,26 @@ public class PassageAuth {
     
     /// Initiates an email change for the currently authenticated user. An email will be sent to the provided email, which they will need to verify before the change takes effect.
     ///
-    /// Still some issues to work out with Passkeys, so this is private for now.
-    ///
     /// - Parameters:
     ///   - token: The user's auth token
     ///   - newEmail: string - valid email address
     ///   - language: optional language string for localizing emails, if no lanuage or an invalid language is provided the application default lanuage will be used
     /// - Returns: ``MagicLink``
     /// - Throws: ``PassageAPIError``, ``PassageError``
-    private static func changeEmail(token: String, newEmail: String, language: String? = nil) async throws -> MagicLink {
-        var magicLink: MagicLink?
+    public static func changeEmail(token: String, newEmail: String, language: String? = nil) async throws -> MagicLink {
         do {
-            magicLink = try await PassageAPIClient.shared.changeEmail(token: token, newEmail: newEmail, magicLinkPath: nil, redirectUrl: nil, language: language)
-        } catch (let error as PassageAPIError) {
-            try PassageAuth.handlePassageAPIError(error: error)
+            let magicLink = try await PassageAPIClient.shared
+                .changeEmail(token: token, newEmail: newEmail, magicLinkPath: nil, redirectUrl: nil, language: language)
+            return magicLink
         } catch {
+            if let apiError = error as? PassageAPIError {
+                try PassageAuth.handlePassageAPIError(error: apiError)
+            }
             throw error
-        }
-        if let unwrappedMagicLink = magicLink {
-            return unwrappedMagicLink
-        } else {
-            throw PassageError.unknown
         }
     }
     
     /// Initiates a phone number change for the currently authenticated user. A text will be sent to the provided phone number, which they will need to verify before the change takes effect.
-    ///
-    /// Still some issues to work out with Passkeys, so this is private for now.
     ///
     /// - Parameters:
     ///   - token: The user's auth token
@@ -1011,19 +1000,16 @@ public class PassageAuth {
     ///   - language: optional language string for localizing emails, if no lanuage or an invalid language is provided the application default lanuage will be used
     /// - Returns: ``MagicLink``
     /// - Throws: ``PassageAPIError``, ``PassageError``
-    private static func changePhone(token: String, newPhone: String, language: String? = nil) async throws -> MagicLink {
-        var magicLink: MagicLink?
+    public static func changePhone(token: String, newPhone: String, language: String? = nil) async throws -> MagicLink {
         do {
-            magicLink = try await PassageAPIClient.shared.changePhone(token: token, newPhone: newPhone, magicLinkPath: nil, redirectUrl: nil, language: language)
-        } catch (let error as PassageAPIError) {
-            try PassageAuth.handlePassageAPIError(error: error)
+            let magicLink = try await PassageAPIClient.shared
+                .changePhone(token: token, newPhone: newPhone, magicLinkPath: nil, redirectUrl: nil, language: language)
+            return magicLink
         } catch {
+            if let apiError = error as? PassageAPIError {
+                try PassageAuth.handlePassageAPIError(error: apiError)
+            }
             throw error
-        }
-        if let unwrappedMagicLink = magicLink {
-            return unwrappedMagicLink
-        } else {
-            throw PassageError.unknown
         }
     }
     

--- a/Sources/Passage/PassageAuth.swift
+++ b/Sources/Passage/PassageAuth.swift
@@ -284,13 +284,14 @@ public class PassageAuth {
     /// - Returns: ``AuthResult``
     /// - Throws: ``PassageAPIError``, ``PassageError``
     @available(iOS 16.0, *)
-    public func addDevice() async throws -> Void {
+    public func addDevice() async throws -> DeviceInfo {
         
         guard let token = self.tokenStore.authToken else {
             throw PassageError.unauthorized
         }
         
-        try await PassageAuth.addDevice(token: token)        
+        let device = try await PassageAuth.addDevice(token: token)
+        return device
     }
 
     

--- a/Sources/Passage/PassageModels.swift
+++ b/Sources/Passage/PassageModels.swift
@@ -44,7 +44,7 @@ public struct PassageUserInfo: Codable {
     /// does the user support webauthn
     public let webauthn: Bool?
     /// Devices the user has used webauthn on
-    public let webauthnDevices: [WebauthnDevice]?
+    public let webauthnDevices: [DeviceInfo]?
     /// types of webauthn the user has used - passkey or platform
     public let webauthnTypes: [String]?
     
@@ -63,12 +63,6 @@ public struct PassageUserInfo: Codable {
         case webauthnDevices = "webauthn_devices"
         case webauthnTypes = "webauthn_types"
     }
-}
-
-
-/// Devices used with webauthn
-public struct WebauthnDevice: Codable {
-    public var id: String
 }
 
 /// Struct describing a Passage Application

--- a/Sources/Passage/PassageSettings.swift
+++ b/Sources/Passage/PassageSettings.swift
@@ -24,6 +24,7 @@ internal class PassageSettings : PassageAuthSettings {
     internal var authOrigin: String?
     internal var apiUrl: String? = "https://auth.passage.id"
     internal var version: String
+    internal var language: String?
     
     internal static let shared = PassageSettings()
     
@@ -52,6 +53,9 @@ internal class PassageSettings : PassageAuthSettings {
             }
             if let apiUrl = unwrappedConfig["apiUrl"] {
                 self.apiUrl = apiUrl
+            }
+            if let language = unwrappedConfig["language"] {
+                self.language = language
             }
             else {
                 self.apiUrl = "https://auth.passage.id"

--- a/Tests/Integration/IntegrationTestData.swift
+++ b/Tests/Integration/IntegrationTestData.swift
@@ -7,15 +7,17 @@ let authToken = ProcessInfo.processInfo.environment["PASSAGE_AUTH_TOKEN"]!
 let mailosaurAPIKey = ProcessInfo.processInfo.environment["MAILOSAUR_API_KEY"]!
 
 let unregisteredUserEmail = "unregistered-test-user@passage.id"
-let registeredUserEmail = "blayne.bayer+integrationtest@passge.id"
+let registeredUserEmail = "ricky.padilla+user01@passage.id"
+let magicLinkAppId = "czLTOVFIytGqrhRVoHV9o8Wo"
+let magicLinkRegisteredUserEmail = "blayne.bayer@passage.id"
 
-let registeredUser = PassageUserInfo(
-    createdAt: "",
-    email:"blayne.bayer@passage.id",
+let currentUser = PassageUserInfo(
+    createdAt: "2023-07-17T17:45:41.807075Z",
+    email: "ricky.padilla+user01@passage.id",
     emailVerified: true,
-    id: "BMQ9Jbi90ubPvX9H1XU5oyfR",
+    id: "sjHQv68O5gnS2ipj0Rb4IkKy",
     lastLoginAt: "",
-    loginCount: 1,
+    loginCount: 2,
     phone: "",
     phoneVerified: false,
     status: "active",
@@ -25,33 +27,16 @@ let registeredUser = PassageUserInfo(
     webauthnTypes: []
 )
 
-let currentUser = PassageUserInfo(
-    createdAt: "2023-02-16T15:55:28.890571Z",
-    email: "blayne.bayer@passage.id",
-    emailVerified: true,
-    id: "BMQ9Jbi90ubPvX9H1XU5oyfR",
-    lastLoginAt: "2023-02-16T19:55:38.907657Z",
-    loginCount: 2,
-    phone: "",
-    phoneVerified: false,
-    status: "active",
-    updatedAt: "2023-02-16T19:55:38.909048Z",
-    webauthn: true,
-    webauthnDevices: [],
-    webauthnTypes: []
-)
-
-
 let appInfoValid = AppInfo(
     allowedIdentifier: "both",
-    authFallbackMethodString: "magic_link",
-    authOrigin: "http://localhost:4173",
+    authFallbackMethodString: "otp",
+    authOrigin: "https://try-uat.passage.dev",
     ephemeral: false,
-    id: "czLTOVFIytGqrhRVoHV9o8Wo",
+    id: "jlSg3Vr4MyKi1dcl3otVz9xa",
     loginURL: "/",
-    name: "passage-ios uat",
+    name: "iOS Integration Test App",
     publicSignup: true,
-    redirectURL: "/dashboard",
+    redirectURL: "/",
     requiredIdentifier: "both",
     requireEmailVerification: false,
     requireIdentifierVerification: false,

--- a/Tests/Integration/PassageAPIClient/ChangeContactTests.swift
+++ b/Tests/Integration/PassageAPIClient/ChangeContactTests.swift
@@ -19,7 +19,7 @@ final class ChangeContactTests: XCTestCase {
         do {
             PassageAPIClient.shared.appId = appInfoValid.id
             let response = try await PassageAPIClient.shared
-                .changeEmail(token: authToken, newEmail: "blayne.bayer+2@passage.id", magicLinkPath: nil, redirectUrl: nil, language: nil)
+                .changeEmail(token: authToken, newEmail: "ricky.padilla+user02@passage.id", magicLinkPath: nil, redirectUrl: nil, language: nil)
             XCTAssertNotNil(response.id)
         } catch {
             XCTAssertTrue(false)
@@ -30,7 +30,7 @@ final class ChangeContactTests: XCTestCase {
         do {
             PassageAPIClient.shared.appId = appInfoValid.id
             let _ = try await PassageAPIClient.shared
-                .changeEmail(token: "", newEmail: "blayne.bayer+2@passage.id", magicLinkPath: nil, redirectUrl: nil, language: nil)
+                .changeEmail(token: "", newEmail: "ricky.padilla+user02@passage.id", magicLinkPath: nil, redirectUrl: nil, language: nil)
             XCTAssertTrue(false)
         } catch {
             XCTAssertTrue(error is PassageAPIError)

--- a/Tests/Integration/PassageAPIClient/DeviceTests.swift
+++ b/Tests/Integration/PassageAPIClient/DeviceTests.swift
@@ -20,9 +20,8 @@ final class ListDevicesTests: XCTestCase {
         do {
             PassageAPIClient.shared.appId = appInfoValid.id
             let response = try await PassageAPIClient.shared.listDevices(token: authToken)
-            XCTAssertGreaterThan(response.count, 0)
-            XCTAssertEqual(response.count, 2)
-            XCTAssertEqual(response[0].userId,currentUser.id)
+            XCTAssertEqual(response.count, 1)
+            XCTAssertEqual(response[0].userId, currentUser.id)
         } catch {
             XCTAssertTrue(false)
         }

--- a/Tests/Integration/PassageAPIClient/GetUserTests.swift
+++ b/Tests/Integration/PassageAPIClient/GetUserTests.swift
@@ -16,7 +16,7 @@ final class GetUserTests: XCTestCase {
     func testUserFound() async {
         do {
             PassageAPIClient.shared.appId = appInfoValid.id
-            let response = try await PassageAPIClient.shared.getUser(identifier: registeredUser.email ?? "")
+            let response = try await PassageAPIClient.shared.getUser(identifier: registeredUserEmail)
             XCTAssertEqual(response.id, currentUser.id)
             XCTAssertEqual(response.status, currentUser.status)
             XCTAssertEqual(response.email, currentUser.email)

--- a/Tests/Integration/PassageAPIClient/MagicLinkTests.swift
+++ b/Tests/Integration/PassageAPIClient/MagicLinkTests.swift
@@ -6,7 +6,7 @@ final class MagicLinkTests: XCTestCase {
     override func setUp() {
         super.setUp()
         PassageSettings.shared.apiUrl = apiUrl
-        PassageSettings.shared.appId = appInfoValid.id
+        PassageSettings.shared.appId = magicLinkAppId
     }
     
     override func tearDown() {
@@ -16,7 +16,7 @@ final class MagicLinkTests: XCTestCase {
     @available(iOS 15.0, *)
     func testSendRegisterMagicLink() async {
         do {
-            PassageAPIClient.shared.appId = appInfoValid.id
+            PassageAPIClient.shared.appId = magicLinkAppId
             let date = Date().timeIntervalSince1970
             let identifier = "authentigator+\(date)@passage.id"
             let response = try await PassageAPIClient.shared
@@ -34,9 +34,9 @@ final class MagicLinkTests: XCTestCase {
     
     func testSendLoginMagicLink() async {
         do {
-            PassageAPIClient.shared.appId = appInfoValid.id
+            PassageAPIClient.shared.appId = magicLinkAppId
             let response = try await PassageAPIClient.shared
-                .sendLoginMagicLink(identifier: registeredUser.email ?? "", path: nil, language: nil)
+                .sendLoginMagicLink(identifier: magicLinkRegisteredUserEmail, path: nil, language: nil)
             do {
                 _ = try await PassageAPIClient.shared.magicLinkStatus(id: response.id)
                 XCTAssertTrue(false) // the status should error as it is unactivated
@@ -51,7 +51,7 @@ final class MagicLinkTests: XCTestCase {
     
     func testActivateMagicLink() async {
         do {
-            PassageAPIClient.shared.appId = appInfoValid.id
+            PassageAPIClient.shared.appId = magicLinkAppId
             let date = Date().timeIntervalSince1970
             let identifier = "authentigator+\(date)@\(MailosaurAPIClient.serverId).mailosaur.net"
             let response = try await PassageAPIClient.shared

--- a/Tests/PassageTests/MockPassageAPIClient.swift
+++ b/Tests/PassageTests/MockPassageAPIClient.swift
@@ -49,7 +49,7 @@ final class MockPassageAPIClient: PassageAuthAPIClient {
     }
     
     @available(iOS 16.0, *)
-    func addDeviceFinish(token: String, startResponse: Passage.WebauthnRegisterStartResponse, params: ASAuthorizationPlatformPublicKeyCredentialRegistration) async throws -> Void {
+    func addDeviceFinish(token: String, startResponse: Passage.WebauthnRegisterStartResponse, params: ASAuthorizationPlatformPublicKeyCredentialRegistration) async throws -> Passage.DeviceInfo {
         throw PassageError.unknown
     }
     


### PR DESCRIPTION
This PR includes the following updates:
* User can now call `changeEmail` and `changePhone`
* Calling `addDevice` will now return that device's/passkey's info
* `UserInfo.webauthnDevices` now includes the device's/passkey's info
* User can set the app's language in `Passage.plist` (for messages sent to user outside of app)