### PR TITLE
Remove need for `Passage.plist` config file

### DIFF
--- a/Sources/Passage/AuthorizationController/LoginAuthoirzationControllerProtocol.swift
+++ b/Sources/Passage/AuthorizationController/LoginAuthoirzationControllerProtocol.swift
@@ -5,8 +5,6 @@ import AuthenticationServices
 @available(iOS 16.0, *)
 protocol LoginAuthorizationControllerProtocol: NSObject, ASAuthorizationControllerDelegate {
     
-    func loginWithIdentifier(from response: WebauthnLoginStartResponse, identifier: String) async throws -> ASAuthorizationPlatformPublicKeyCredentialAssertion
-    
     func login(from response: WebauthnLoginStartResponse) async throws -> ASAuthorizationPlatformPublicKeyCredentialAssertion?
     
     func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization)

--- a/Sources/Passage/AuthorizationController/LoginAuthorizationController.swift
+++ b/Sources/Passage/AuthorizationController/LoginAuthorizationController.swift
@@ -11,27 +11,6 @@ class LoginAuthorizationController : NSObject, ASAuthorizationControllerDelegate
 
     static var shared: LoginAuthorizationControllerProtocol = LoginAuthorizationController()
     
-    func loginWithIdentifier(from response: WebauthnLoginStartResponse, identifier: String) async throws -> ASAuthorizationPlatformPublicKeyCredentialAssertion {
-        PassageAutofillAuthorizationController.shared.cancel()
-        let rpId = response.handshake.challenge.publicKey.rpId
-        let publicKeyCredentialProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: rpId)
-        let challenge = response.handshake.challenge.publicKey.challenge
-        let decodedChallenge = challenge.decodeBase64Url()
-        let assertionRequest = publicKeyCredentialProvider.createCredentialAssertionRequest(challenge: decodedChallenge!)
-        let authController = ASAuthorizationController(authorizationRequests: [ assertionRequest ] )
-        authController.delegate = self
-        authController.performRequests()
-        
-        return try await withCheckedThrowingContinuation(
-            { [weak self] (continuation: CredentialAssertionCheckedThrowingContinuation) in
-                guard let self = self else {
-                    return
-                }
-                self.credentialAssertionThrowingContinuation = continuation
-            }
-        )
-    }
-    
     func login(from response: WebauthnLoginStartResponse) async throws -> ASAuthorizationPlatformPublicKeyCredentialAssertion? {
         PassageAutofillAuthorizationController.shared.cancel()
         let rpId = response.handshake.challenge.publicKey.rpId

--- a/Sources/Passage/AuthorizationController/LoginAuthorizationController.swift
+++ b/Sources/Passage/AuthorizationController/LoginAuthorizationController.swift
@@ -1,11 +1,3 @@
-//
-//  PassageAuthAsyncAuthorizationController.swift
-//  Shiny
-//
-//  Created by blayne bayer on 8/24/22.
-//  Copyright © 2022 Apple. All rights reserved.
-//
-
 import Foundation
 import os
 import AuthenticationServices
@@ -17,19 +9,12 @@ class LoginAuthorizationController : NSObject, ASAuthorizationControllerDelegate
         CheckedContinuation<ASAuthorizationPlatformPublicKeyCredentialAssertion, Error>
     private var credentialAssertionThrowingContinuation: CredentialAssertionCheckedThrowingContinuation? = nil
 
-    
     static var shared: LoginAuthorizationControllerProtocol = LoginAuthorizationController()
-    
-    public var domain: String
-    
-    private override init() {
-        self.domain = PassageSettings.shared.authOrigin!
-    }
-    
     
     func loginWithIdentifier(from response: WebauthnLoginStartResponse, identifier: String) async throws -> ASAuthorizationPlatformPublicKeyCredentialAssertion {
         PassageAutofillAuthorizationController.shared.cancel()
-        let publicKeyCredentialProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: domain)
+        let rpId = response.handshake.challenge.publicKey.rpId
+        let publicKeyCredentialProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: rpId)
         let challenge = response.handshake.challenge.publicKey.challenge
         let decodedChallenge = challenge.decodeBase64Url()
         let assertionRequest = publicKeyCredentialProvider.createCredentialAssertionRequest(challenge: decodedChallenge!)
@@ -49,7 +34,8 @@ class LoginAuthorizationController : NSObject, ASAuthorizationControllerDelegate
     
     func login(from response: WebauthnLoginStartResponse) async throws -> ASAuthorizationPlatformPublicKeyCredentialAssertion? {
         PassageAutofillAuthorizationController.shared.cancel()
-        let publicKeyCredentialProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: domain)
+        let rpId = response.handshake.challenge.publicKey.rpId
+        let publicKeyCredentialProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: rpId)
         let challenge = response.handshake.challenge.publicKey.challenge
         let decodedChallenge = challenge.decodeBase64Url()
         let assertionRequest = publicKeyCredentialProvider.createCredentialAssertionRequest(challenge: decodedChallenge!)

--- a/Sources/Passage/AuthorizationController/PassageAutofillAuthorizationController.swift
+++ b/Sources/Passage/AuthorizationController/PassageAutofillAuthorizationController.swift
@@ -1,11 +1,3 @@
-//
-//  PassageAutoFillAuthorizationController.swift
-//  Shiny
-//
-//  Created by blayne bayer on 8/22/22.
-//  Copyright © 2022 Apple. All rights reserved.
-//
-
 import Foundation
 import AuthenticationServices
 import os
@@ -52,9 +44,11 @@ public class PassageAutofillAuthorizationController : NSObject, ASAuthorizationC
         self.onCancel = onCancel
         
         self.authenticationAnchor = anchor
-        self.startResponse = try await PassageAuth.autoFillStart()
+        let startResponse = try await PassageAuth.autoFillStart()
+        self.startResponse = startResponse
         
-        let publicKeyCredentialProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: PassageSettings.shared.authOrigin!)
+        let rpId = startResponse.handshake.challenge.publicKey.rpId
+        let publicKeyCredentialProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: rpId)
         
         let challenge = self.startResponse!.handshake.challenge.publicKey.challenge
         let decodedChallenge = challenge.decodeBase64Url()

--- a/Sources/Passage/AuthorizationController/RegistrationAuthorizationController.swift
+++ b/Sources/Passage/AuthorizationController/RegistrationAuthorizationController.swift
@@ -1,11 +1,3 @@
-//
-//  PassageAuthAsyncAuthorizationController.swift
-//  Shiny
-//
-//  Created by blayne bayer on 8/24/22.
-//  Copyright © 2022 Apple. All rights reserved.
-//
-
 import Foundation
 import os
 import AuthenticationServices
@@ -21,18 +13,13 @@ class RegistrationAuthorizationController : NSObject, ASAuthorizationControllerD
     
     static var shared: RegistrationAuthorizationControllerProtocol = RegistrationAuthorizationController()
     
-    public var domain: String
-    
-    private override init() {
-        self.domain = PassageSettings.shared.authOrigin!
-    }
-    
-    
     func register(from response: WebauthnRegisterStartResponse, identifier: String) async throws -> ASAuthorizationPlatformPublicKeyCredentialRegistration? {
         
         PassageAutofillAuthorizationController.shared.cancel()
         
-        let publicKeyCredentialProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: domain)
+        let rpId = response.handshake.challenge.publicKey.rp.id
+        
+        let publicKeyCredentialProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: rpId)
         
         let challenge = response.handshake.challenge.publicKey.challenge
         let userId = response.user.id

--- a/Sources/Passage/PassageAuth.swift
+++ b/Sources/Passage/PassageAuth.swift
@@ -411,21 +411,6 @@ public class PassageAuth {
         return authResult
     }
     
-    /// Login a user by their identifier (Not supported at this time)
-    ///
-    /// This method is currently not supported in iOS
-    /// Currently only passkey login is supported. Does not use passkey.
-    /// - Parameter identifier: <#identifier description#>
-    /// - Returns: <#description#>
-    /// - Throws: ``PassageAPIError``,``PassageASAuthorizationError``, ``PassageError``
-    @available(iOS 16.0, *)
-    private func loginWithIdentifier(identifier: String) async throws -> AuthResult {
-        self.clearTokens()
-        let authResult = try await PassageAuth.loginWithIdentifier(identifier: identifier)
-        self.setTokensFromAuthResult(authResult: authResult)
-        return authResult
-    }
-    
     private func clearTokens() -> Void {
         self.tokenStore.clearTokens()
     }

--- a/Sources/Passage/PassageAuth.swift
+++ b/Sources/Passage/PassageAuth.swift
@@ -25,6 +25,16 @@ public class PassageAuth {
         self.tokenStore = tokenStore
     }
     
+    public init(appId: String) {
+        self.tokenStore = PassageStore.shared
+        PassageSettings.shared.appId = appId
+    }
+    
+    public init(appId: String, tokenStore: PassageTokenStore) {
+        self.tokenStore = tokenStore
+        PassageSettings.shared.appId = appId
+    }
+    
     // MARK: Instance Public Methods
     
 

--- a/Sources/Passage/PassageAuth.swift
+++ b/Sources/Passage/PassageAuth.swift
@@ -1070,37 +1070,6 @@ public class PassageAuth {
 
     }
     
-    /// Login a user by their identifier (Not supported at this time)
-    ///
-    /// This method is currently not supported in iOS
-    /// Currently only passkey login is supported. Does not use passkey.
-    /// - Parameter identifier: <#identifier description#>
-    /// - Returns: <#description#>
-    /// - Throws: ``PassageAPIError``,``PassageASAuthorizationError``, ``PassageError``
-    @available(iOS 16.0, *)
-    private static func loginWithIdentifier(identifier: String) async throws -> AuthResult {
-        var authResult: AuthResult?
-        do {
-            // if error status code of 404 userNotFound
-            let loginWithIdentifierStartResponse = try await PassageAPIClient.shared.webauthnLoginWithIdentifierStart(identifier: identifier )
-            
-            let credentialAssertion = try await LoginAuthorizationController.shared.loginWithIdentifier(from: loginWithIdentifierStartResponse, identifier: identifier)
-            
-            authResult = try await PassageAPIClient.shared.webauthnLoginWithIdentifierFinish(startResponse: loginWithIdentifierStartResponse, credentialAssertion: credentialAssertion)
-        } catch (let error as PassageAPIError) {
-            try PassageAuth.handlePassageAPIError(error: error)
-        }
-        catch {
-            throw error
-        }
-        
-        if let unwrappedAuthResult = authResult {
-            return unwrappedAuthResult
-        } else {
-            throw PassageError.unknown
-        }
-    }
-    
     /// Private method to instantiate a logger and log the errors we catch
     ///
     /// - Parameters:

--- a/Sources/Passage/PassageAuth.swift
+++ b/Sources/Passage/PassageAuth.swift
@@ -351,6 +351,9 @@ public class PassageAuth {
         return tokens.authToken
     }
     
+    public func overrideApiUrl(with newUrl: String) {
+        PassageSettings.shared.apiUrl = newUrl
+    }
     
     // MARK: Instance Private Methods
     

--- a/Sources/Passage/PassageSettings.swift
+++ b/Sources/Passage/PassageSettings.swift
@@ -9,7 +9,6 @@ import Foundation
 import os
 protocol PassageAuthSettings {
     var appId: String? { get set }
-    var authOrigin: String? { get set }
     var apiUrl: String? { get set }
 }
 
@@ -21,7 +20,6 @@ internal class PassageSettings : PassageAuthSettings {
     
     // MARK: - Properties
     internal var appId: String?
-    internal var authOrigin: String?
     internal var apiUrl: String? = "https://auth.passage.id"
     internal var version: String
     internal var language: String?
@@ -47,9 +45,6 @@ internal class PassageSettings : PassageAuthSettings {
         if let unwrappedConfig = config {
             if let appId = unwrappedConfig["appId"] {
                 self.appId = appId
-            }
-            if let authOrigin = unwrappedConfig["authOrigin"] {
-                self.authOrigin = authOrigin
             }
             if let apiUrl = unwrappedConfig["apiUrl"] {
                 self.apiUrl = apiUrl

--- a/Tests/Integration/IntegrationTestData.swift
+++ b/Tests/Integration/IntegrationTestData.swift
@@ -6,6 +6,8 @@ let apiUrl = "https://auth-uat.passage.dev"
 let authToken = ProcessInfo.processInfo.environment["PASSAGE_AUTH_TOKEN"]!
 let mailosaurAPIKey = ProcessInfo.processInfo.environment["MAILOSAUR_API_KEY"]!
 
+let checkEmailWaitTime = UInt64(4 * Double(NSEC_PER_SEC))// nanoseconds
+
 let unregisteredUserEmail = "unregistered-test-user@passage.id"
 let registeredUserEmail = "ricky.padilla+user01@passage.id"
 let magicLinkAppId = "czLTOVFIytGqrhRVoHV9o8Wo"

--- a/Tests/Integration/MailosaurClient.swift
+++ b/Tests/Integration/MailosaurClient.swift
@@ -75,6 +75,7 @@ internal class MailosaurAPIClient {
             let messages = try await listMessages()
             guard !messages.isEmpty else { return "" }
             let message = try await getMessage(id: messages[0].id)
+            guard !message.html.links.isEmpty else { return "" }
             let incomingURL = message.html.links[0].href
             let components = NSURLComponents(url: URL(string: incomingURL)!, resolvingAgainstBaseURL: true)
             guard let magicLink = components!.queryItems?.filter({$0.name == "psg_magic_link"}).first?.value else {

--- a/Tests/Integration/PassageAPIClient/MagicLinkTests.swift
+++ b/Tests/Integration/PassageAPIClient/MagicLinkTests.swift
@@ -56,7 +56,7 @@ final class MagicLinkTests: XCTestCase {
             let identifier = "authentigator+\(date)@\(MailosaurAPIClient.serverId).mailosaur.net"
             let response = try await PassageAPIClient.shared
                 .sendRegisterMagicLink(identifier: identifier, path: nil, language: nil)
-            try await Task.sleep(nanoseconds: UInt64(3 * Double(NSEC_PER_SEC)))
+            try await Task.sleep(nanoseconds: checkEmailWaitTime)
             let magicLink = try await MailosaurAPIClient().getMostRecentMagicLink()
             let token = try await PassageAPIClient.shared.activateMagicLink(magicLink: magicLink)
             XCTAssertNotNil(token)

--- a/Tests/Integration/PassageAPIClient/OneTimePasscodeTests.swift
+++ b/Tests/Integration/PassageAPIClient/OneTimePasscodeTests.swift
@@ -45,7 +45,7 @@ final class OneTimePasscodeTests: XCTestCase {
             let identifier = "authentigator+\(date)@\(MailosaurAPIClient.serverId).mailosaur.net"
             let response = try await PassageAPIClient.shared
                 .sendRegisterOneTimePasscode(identifier: identifier, language: nil)
-            try await Task.sleep(nanoseconds: UInt64(3 * Double(NSEC_PER_SEC)))
+            try await Task.sleep(nanoseconds: checkEmailWaitTime)
             let oneTimePasscode = try await MailosaurAPIClient().getMostRecentOneTimePasscode()
             let token = try await PassageAPIClient.shared.activateOneTimePasscode(otp: oneTimePasscode, otpId: response.id)
             XCTAssertNotNil(token)

--- a/Tests/Integration/PassageAPIClient/SessionTests.swift
+++ b/Tests/Integration/PassageAPIClient/SessionTests.swift
@@ -21,7 +21,7 @@ final class SessionTests: XCTestCase {
             let identifier = "authentigator+\(date)@\(MailosaurAPIClient.serverId).mailosaur.net"
             _ = try await PassageAPIClient.shared
                 .sendRegisterMagicLink(identifier: identifier, path: nil, language: nil)
-            try await Task.sleep(nanoseconds: UInt64(3 * Double(NSEC_PER_SEC)))
+            try await Task.sleep(nanoseconds: checkEmailWaitTime)
             let magicLink = try await MailosaurAPIClient().getMostRecentMagicLink()
             let tokens = try await PassageAPIClient.shared.activateMagicLink(magicLink: magicLink)
             XCTAssertNotNil(tokens.refreshToken)

--- a/Tests/PassageTests/MockLoginAuthorizationController.swift
+++ b/Tests/PassageTests/MockLoginAuthorizationController.swift
@@ -4,10 +4,6 @@ import AuthenticationServices
 @available(iOS 16.0, *)
 class MockLoginAuthorizationController : NSObject, ASAuthorizationControllerDelegate, LoginAuthorizationControllerProtocol {
     
-    func loginWithIdentifier(from response: Passage.WebauthnLoginStartResponse, identifier: String) async throws -> ASAuthorizationPlatformPublicKeyCredentialAssertion {
-        throw PassageError.unknown
-    }
-    
     func login(from response: Passage.WebauthnLoginStartResponse) async throws -> ASAuthorizationPlatformPublicKeyCredentialAssertion? {
         return nil
     }

--- a/Tests/PassageTests/PassageAuthStaticTests.swift
+++ b/Tests/PassageTests/PassageAuthStaticTests.swift
@@ -6,7 +6,6 @@ final class PassageAuthStaticTests: XCTestCase {
     override func setUp() {
         super.setUp()
         PassageSettings.shared.appId = testAppInfo.id
-        PassageSettings.shared.authOrigin = testAppInfo.authOrigin
         PassageSettings.shared.apiUrl = "TEST_API_URL"
         PassageAPIClient.shared = MockPassageAPIClient()
         if #available(iOS 16.0, *) {


### PR DESCRIPTION
While you can still use the "Passage.plist" file for configuring your app for Passage if you want, you can now use the iOS Passage SDK without it by initializing an instance of `PassageAuth` with your Passage app id, like this:

```swift
let passage = PassageAuth(appId: "ABCDEF123456")
```

### Additional updates in this PR:
* Removed "authOrigin" property from `PassageSettings`, as it is not necessary
* Removed a private, unused method (`loginWithIdentifier`)
* Updated some unit and integration tests