### PR TITLE
Add retries to Mailosaur email checks in integration tests.

### DIFF
--- a/Tests/Integration/IntegrationTestData.swift
+++ b/Tests/Integration/IntegrationTestData.swift
@@ -6,7 +6,8 @@ let apiUrl = "https://auth-uat.passage.dev"
 let authToken = ProcessInfo.processInfo.environment["PASSAGE_AUTH_TOKEN"]!
 let mailosaurAPIKey = ProcessInfo.processInfo.environment["MAILOSAUR_API_KEY"]!
 
-let checkEmailWaitTime = UInt64(6 * Double(NSEC_PER_SEC))// nanoseconds
+let checkEmailWaitTime = UInt64(4 * Double(NSEC_PER_SEC))// nanoseconds
+let checkEmailTryCount = 3
 
 let unregisteredUserEmail = "unregistered-test-user@passage.id"
 let registeredUserEmail = "ricky.padilla+user01@passage.id"

--- a/Tests/Integration/MailosaurClient.swift
+++ b/Tests/Integration/MailosaurClient.swift
@@ -70,35 +70,26 @@ internal class MailosaurAPIClient {
         return "Basic: \(apiKey!)"
     }
     
-    func getMostRecentMagicLink() async throws -> String {
-        do{
-            let messages = try await listMessages()
-            guard !messages.isEmpty else { return "" }
-            let message = try await getMessage(id: messages[0].id)
-            guard !message.html.links.isEmpty else { return "" }
-            let incomingURL = message.html.links[0].href
-            let components = NSURLComponents(url: URL(string: incomingURL)!, resolvingAgainstBaseURL: true)
-            guard let magicLink = components!.queryItems?.filter({$0.name == "psg_magic_link"}).first?.value else {
-                return ""
-            }
-            return magicLink
-        } catch {
-            print(error)
-            return ""
-        }
+    func getMostRecentMagicLink() async -> String? {
+        guard let messages = try? await listMessages(),
+              !messages.isEmpty,
+              let message = try? await getMessage(id: messages[0].id),
+              !message.html.links.isEmpty,
+              let incomingURL = URL(string: message.html.links[0].href),
+              let components = NSURLComponents(url: incomingURL, resolvingAgainstBaseURL: true),
+              let magicLink = components.queryItems?.filter({$0.name == "psg_magic_link"}).first?.value
+        else { return nil }
+        return magicLink
     }
     
-    func getMostRecentOneTimePasscode() async throws -> String {
-        do{
-            let messages = try await listMessages()
-            guard !messages.isEmpty else { return "" }
-            let message = try await getMessage(id: messages[0].id)
-            let oneTimePasscode = message.html.codes.isEmpty ? "" : message.html.codes[0].value
-            return oneTimePasscode
-        } catch {
-            print(error)
-            return ""
-        }
+    func getMostRecentOneTimePasscode() async -> String? {
+        guard let messages = try? await listMessages(),
+              !messages.isEmpty,
+              let message = try? await getMessage(id: messages[0].id),
+              !message.html.codes.isEmpty
+        else { return nil }
+        let oneTimePasscode = message.html.codes[0].value
+        return oneTimePasscode
     }
     
     func getMessage(id: String) async throws -> GetMessageResponse {

--- a/Tests/Integration/PassageAPIClient/MagicLinkTests.swift
+++ b/Tests/Integration/PassageAPIClient/MagicLinkTests.swift
@@ -48,7 +48,7 @@ final class MagicLinkTests: XCTestCase {
             XCTAssertTrue(false)
         }
     }
-    /*
+
     func testActivateMagicLink() async {
         do {
             PassageAPIClient.shared.appId = magicLinkAppId
@@ -56,8 +56,17 @@ final class MagicLinkTests: XCTestCase {
             let identifier = "authentigator+\(date)@\(MailosaurAPIClient.serverId).mailosaur.net"
             let response = try await PassageAPIClient.shared
                 .sendRegisterMagicLink(identifier: identifier, path: nil, language: nil)
-            try await Task.sleep(nanoseconds: checkEmailWaitTime)
-            let magicLink = try await MailosaurAPIClient().getMostRecentMagicLink()
+            var magicLink: String? = nil
+            let mailosaurApiClient = MailosaurAPIClient()
+            for _ in 1...checkEmailTryCount {
+                try? await Task.sleep(nanoseconds: checkEmailWaitTime)
+                magicLink = await mailosaurApiClient.getMostRecentMagicLink()
+                if magicLink != nil {
+                    break
+                }
+            }
+            XCTAssertNotNil(magicLink)
+            guard let magicLink else { return }
             let token = try await PassageAPIClient.shared.activateMagicLink(magicLink: magicLink)
             XCTAssertNotNil(token)
             do {
@@ -71,6 +80,6 @@ final class MagicLinkTests: XCTestCase {
             XCTAssertTrue(false)
         }
     }
-    */
+
 }
 

--- a/Tests/Integration/PassageAPIClient/OneTimePasscodeTests.swift
+++ b/Tests/Integration/PassageAPIClient/OneTimePasscodeTests.swift
@@ -37,7 +37,7 @@ final class OneTimePasscodeTests: XCTestCase {
             XCTAssertTrue(false)
         }
     }
-    /*
+
     func testActivateOneTimePasscode() async {
         do {
             PassageAPIClient.shared.appId = otpAppInfoValid.id
@@ -45,8 +45,18 @@ final class OneTimePasscodeTests: XCTestCase {
             let identifier = "authentigator+\(date)@\(MailosaurAPIClient.serverId).mailosaur.net"
             let response = try await PassageAPIClient.shared
                 .sendRegisterOneTimePasscode(identifier: identifier, language: nil)
-            try await Task.sleep(nanoseconds: checkEmailWaitTime)
-            let oneTimePasscode = try await MailosaurAPIClient().getMostRecentOneTimePasscode()
+            
+            var oneTimePasscode: String? = nil
+            let mailosaurApiClient = MailosaurAPIClient()
+            for _ in 1...checkEmailTryCount {
+                try? await Task.sleep(nanoseconds: checkEmailWaitTime)
+                oneTimePasscode = await mailosaurApiClient.getMostRecentOneTimePasscode()
+                if oneTimePasscode != nil {
+                    break
+                }
+            }
+            XCTAssertNotNil(oneTimePasscode)
+            guard let oneTimePasscode else { return }
             let token = try await PassageAPIClient.shared.activateOneTimePasscode(otp: oneTimePasscode, otpId: response.id)
             XCTAssertNotNil(token)
         } catch {
@@ -54,5 +64,5 @@ final class OneTimePasscodeTests: XCTestCase {
             XCTAssertTrue(false)
         }
     }
-    */
+
 }

--- a/Tests/Integration/PassageAPIClient/SessionTests.swift
+++ b/Tests/Integration/PassageAPIClient/SessionTests.swift
@@ -12,7 +12,7 @@ final class SessionTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
     }
-    /*
+    
     func testRefreshAndSignOut() async {
         do{
             // Sign in and get tokens
@@ -21,8 +21,17 @@ final class SessionTests: XCTestCase {
             let identifier = "authentigator+\(date)@\(MailosaurAPIClient.serverId).mailosaur.net"
             _ = try await PassageAPIClient.shared
                 .sendRegisterMagicLink(identifier: identifier, path: nil, language: nil)
-            try await Task.sleep(nanoseconds: checkEmailWaitTime)
-            let magicLink = try await MailosaurAPIClient().getMostRecentMagicLink()
+            var magicLink: String? = nil
+            let mailosaurApiClient = MailosaurAPIClient()
+            for _ in 1...checkEmailTryCount {
+                try? await Task.sleep(nanoseconds: checkEmailWaitTime)
+                magicLink = await mailosaurApiClient.getMostRecentMagicLink()
+                if magicLink != nil {
+                    break
+                }
+            }
+            XCTAssertNotNil(magicLink)
+            guard let magicLink else { return }
             let tokens = try await PassageAPIClient.shared.activateMagicLink(magicLink: magicLink)
             XCTAssertNotNil(tokens.refreshToken)
             
@@ -57,5 +66,5 @@ final class SessionTests: XCTestCase {
             XCTAssertTrue(false)
         }
     }
-    */
+    
 }


### PR DESCRIPTION
The Mailosaur email checks often failed, resulting in a failed test. This PR add retries to those email checks to make them less flakey.