### PR TITLE
Added `PassageOTPError.exceededAttempts`

### DIFF
--- a/Sources/Passage/PassageAPIClient/PassageAPIError.swift
+++ b/Sources/Passage/PassageAPIClient/PassageAPIError.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct PassageErrorResponseBody : Codable {
     var status: String?
+    var code: String?
     var error: String?
     var errors: [String:String]?
 }

--- a/Sources/Passage/PassageErrors.swift
+++ b/Sources/Passage/PassageErrors.swift
@@ -22,6 +22,11 @@ public enum PassageLoginError: Error {
     case identifierRequired
 }
 
+// OTP Error
+public enum PassageOTPError: Error {
+    case exceededAttempts
+}
+
 /// Any unspecified PassageError
 public enum PassageError: Error, Equatable {
     case unauthorized


### PR DESCRIPTION
Handling the new `exceeded_attempts` error code that is returned when the user has had too many failed activation attempts when activating a one-time passcode.