### PR TITLE
Social auth

### DIFF
--- a/Sources/Passage/AuthorizationController/PassageSocialAuthController.swift
+++ b/Sources/Passage/AuthorizationController/PassageSocialAuthController.swift
@@ -99,15 +99,15 @@ final internal class PassageSocialAuthController:
         verifier = randomString
         let codeChallenge = PassageSocialAuthController.sha256Hash(randomString)
         let codeChallengeMethod = "S256"
-        let params = """
-            redirect_uri=\(redirectURI)&
-            state=\(state)&
-            code_challenge=\(codeChallenge)&
-            code_challenge_method=\(codeChallengeMethod)&
-            connection_type=\(connection.rawValue)
-        """
-            .replacingOccurrences(of: " ", with: "")
-            .replacingOccurrences(of: "\n", with: "")
+        var components = URLComponents()
+        components.queryItems = [
+            URLQueryItem(name: "redirect_uri", value: redirectURI),
+            URLQueryItem(name: "state", value: state),
+            URLQueryItem(name: "code_challenge", value: codeChallenge),
+            URLQueryItem(name: "code_challenge_method", value: codeChallengeMethod),
+            URLQueryItem(name: "connection_type", value: connection.rawValue)
+        ]
+        let params = components.url?.query ?? ""
         return params
     }
         

--- a/Sources/Passage/AuthorizationController/PassageWebAuthenticationController.swift
+++ b/Sources/Passage/AuthorizationController/PassageWebAuthenticationController.swift
@@ -1,0 +1,105 @@
+import AuthenticationServices
+import CommonCrypto
+import Security
+
+public enum PassageSocialConnection: String {
+    case apple
+    case github
+    case google
+}
+
+final internal class PassageWebAuthenticationController: NSObject, ASWebAuthenticationPresentationContextProviding {
+    
+    internal var verifier = ""
+    
+    private var webAuthSession: ASWebAuthenticationSession?
+    private var window: UIWindow
+    
+    // MARK: INIT METHODS
+    
+    init(window: UIWindow) {
+        self.window = window
+    }
+    
+    // MARK: DELEGATE METHODS
+    
+    internal func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        return window
+    }
+    
+    // MARK: STATIC METHODS
+    
+    private static func getRandomString(length: Int) -> String {
+        let characters = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        var randomString = ""
+        for _ in 0..<length {
+            let randomValue = Int(arc4random_uniform(UInt32(characters.count)))
+            randomString += String(characters[characters.index(characters.startIndex, offsetBy: randomValue)])
+        }
+        return randomString
+    }
+    
+    private static func sha256Hash(_ str: String) -> String {
+        let data = Data(str.utf8)
+        var hash = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+        data.withUnsafeBytes {
+            _ = CC_SHA256($0.baseAddress, CC_LONG(data.count), &hash)
+        }
+        let base64EncodedString = Data(hash).base64EncodedString()
+        let base64URL = base64EncodedString
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        return base64URL
+    }
+    
+    // MARK: INSTANCE METHODS
+    
+    internal func getSocialAuthQueryParams(appId: String, connection: PassageSocialConnection) -> String {
+        let redirectURI = "\(appId)://"
+        let state = PassageWebAuthenticationController.getRandomString(length: 32)
+        let randomString = PassageWebAuthenticationController.getRandomString(length: 32)
+        verifier = randomString
+        let codeChallenge = PassageWebAuthenticationController.sha256Hash(randomString)
+        let codeChallengeMethod = "S256"
+        let params = """
+            redirect_uri=\(redirectURI)&
+            state=\(state)&
+            code_challenge=\(codeChallenge)&
+            code_challenge_method=\(codeChallengeMethod)&
+            connection_type=\(connection.rawValue)
+        """
+            .replacingOccurrences(of: " ", with: "")
+            .replacingOccurrences(of: "\n", with: "")
+        return params
+    }
+        
+    internal func openSecureWebView(
+        url: URL,
+        callbackURLScheme: String,
+        prefersEphemeralWebBrowserSession: Bool
+    ) async throws -> String {
+        return try await withCheckedThrowingContinuation { continuation in
+            webAuthSession = ASWebAuthenticationSession(url: url, callbackURLScheme: callbackURLScheme)
+                { callbackURL, error in
+                    guard error == nil else {
+                        continuation.resume(throwing: error!)
+                        return
+                    }
+                    guard
+                        let callbackURL = callbackURL,
+                        let components = NSURLComponents(url: callbackURL, resolvingAgainstBaseURL: true),
+                        let authCode = components.queryItems?.filter({$0.name == "code"}).first?.value
+                    else {
+                        continuation.resume(throwing: PassageSocialError.missingAuthCode)
+                        return
+                    }
+                    continuation.resume(returning: authCode)
+                }
+            webAuthSession?.presentationContextProvider = self
+            webAuthSession?.prefersEphemeralWebBrowserSession = prefersEphemeralWebBrowserSession
+            webAuthSession?.start()
+        }
+    }
+    
+}

--- a/Sources/Passage/PassageAPIClient/PassageAPIClient.swift
+++ b/Sources/Passage/PassageAPIClient/PassageAPIClient.swift
@@ -443,7 +443,7 @@ internal class PassageAPIClient : PassageAuthAPIClient {
     ///   - code: Social auth code
     ///   - verifier: Social auth verifier
     /// - Returns: ``AuthResult``
-    func exchangeAuthCode(_ code: String, verifier: String) async throws -> AuthResult {
+    func exchange(code: String, verifier: String) async throws -> AuthResult {
         let url = try self.appUrl(path: "social/token?code=\(code)&verifier=\(verifier)")
         let request = buildRequest(url: url, method: "GET")
         let (responseData, response) = try await URLSession.shared.data(for: request)
@@ -460,14 +460,12 @@ internal class PassageAPIClient : PassageAuthAPIClient {
     func exchange(code: String, idToken: String) async throws -> AuthResult {
         let url = try self.appUrl(path: "social/id_token")
         let request = buildRequest(url: url, method: "POST")
-        let data = try JSONSerialization.data(
-            withJSONObject: [
-                "code": code,
-                "id_token": idToken,
-                "connection_type": "apple"
-            ],
-            options: []
-        )
+        let params = [
+            "code": code,
+            "id_token": idToken,
+            "connection_type": "apple"
+        ]
+        let data = try JSONSerialization.data(withJSONObject: params, options: [])
         let (responseData, response) = try await URLSession.shared.upload(for: request, from: data)
         try assertValidResponse(response: response, responseData: responseData)
         let authResultResponse = try JSONDecoder().decode(AuthResultResponse.self, from: responseData)

--- a/Sources/Passage/PassageAPIClient/PassageAPIClient.swift
+++ b/Sources/Passage/PassageAPIClient/PassageAPIClient.swift
@@ -430,6 +430,28 @@ internal class PassageAPIClient : PassageAuthAPIClient {
         return activateOneTimePasscodeResponse.authResult
     }
     
+    /// Get social authorization url
+    /// - Parameters:
+    ///   - queryParams: Request query parameters
+    /// - Returns: ``URL``
+    func getAuthUrl(queryParams: String) throws -> URL {
+        return try self.appUrl(path: "social/authorize?\(queryParams)")
+    }
+    
+    /// Exchange social auth code for AuthResult
+    /// - Parameters:
+    ///   - code: Social auth code
+    ///   - verifier: Social auth verifier
+    /// - Returns: ``AuthResult``
+    func exchangeAuthCode(_ code: String, verifier: String) async throws -> AuthResult {
+        let url = try self.appUrl(path: "social/token?code=\(code)&verifier=\(verifier)")
+        let request = buildRequest(url: url, method: "GET")
+        let (responseData, response) = try await URLSession.shared.data(for: request)
+        try assertValidResponse(response: response, responseData: responseData)
+        let authResultResponse = try JSONDecoder().decode(AuthResultResponse.self, from: responseData)
+        return authResultResponse.authResult
+    }
+    
     /// Get the detail for the current user
     /// - Parameter token: The user's access token
     /// - Returns: ``PassageUserInfo``

--- a/Sources/Passage/PassageAPIClient/PassageAPIClient.swift
+++ b/Sources/Passage/PassageAPIClient/PassageAPIClient.swift
@@ -452,6 +452,28 @@ internal class PassageAPIClient : PassageAuthAPIClient {
         return authResultResponse.authResult
     }
     
+    /// Exchange social auth code and id token for AuthResult
+    /// - Parameters:
+    ///   - code: Social auth code
+    ///   - idToken: Social id token
+    /// - Returns: ``AuthResult``
+    func exchange(code: String, idToken: String) async throws -> AuthResult {
+        let url = try self.appUrl(path: "social/id_token")
+        let request = buildRequest(url: url, method: "POST")
+        let data = try JSONSerialization.data(
+            withJSONObject: [
+                "code": code,
+                "id_token": idToken,
+                "connection_type": "apple"
+            ],
+            options: []
+        )
+        let (responseData, response) = try await URLSession.shared.upload(for: request, from: data)
+        try assertValidResponse(response: response, responseData: responseData)
+        let authResultResponse = try JSONDecoder().decode(AuthResultResponse.self, from: responseData)
+        return authResultResponse.authResult
+    }
+    
     /// Get the detail for the current user
     /// - Parameter token: The user's access token
     /// - Returns: ``PassageUserInfo``

--- a/Sources/Passage/PassageAPIClient/PassageAPIClientProtocol.swift
+++ b/Sources/Passage/PassageAPIClient/PassageAPIClientProtocol.swift
@@ -137,6 +137,18 @@ protocol PassageAuthAPIClient  {
     /// - Returns: ``AuthResult``
     func activateOneTimePasscode(otp: String, otpId: String) async throws -> AuthResult
     
+    /// Get social authorization url
+    /// - Parameters:
+    ///   - queryParams: Request query parameters
+    /// - Returns: ``URL``
+    func getAuthUrl(queryParams: String) throws -> URL
+    
+    /// Exchange social auth code for AuthResult
+    /// - Parameters:
+    ///   - code: Social auth code
+    ///   - verifier: Social auth verifier
+    /// - Returns: ``AuthResult``
+    func exchangeAuthCode(_ code: String, verifier: String) async throws -> AuthResult
     
     /// Get the detail for the current user
     /// - Parameter token: The user's access token

--- a/Sources/Passage/PassageAPIClient/PassageAPIClientProtocol.swift
+++ b/Sources/Passage/PassageAPIClient/PassageAPIClientProtocol.swift
@@ -148,7 +148,7 @@ protocol PassageAuthAPIClient  {
     ///   - code: Social auth code
     ///   - verifier: Social auth verifier
     /// - Returns: ``AuthResult``
-    func exchangeAuthCode(_ code: String, verifier: String) async throws -> AuthResult
+    func exchange(code: String, verifier: String) async throws -> AuthResult
     
     /// Exchange social auth code and id token for AuthResult
     /// - Parameters:

--- a/Sources/Passage/PassageAPIClient/PassageAPIClientProtocol.swift
+++ b/Sources/Passage/PassageAPIClient/PassageAPIClientProtocol.swift
@@ -150,6 +150,13 @@ protocol PassageAuthAPIClient  {
     /// - Returns: ``AuthResult``
     func exchangeAuthCode(_ code: String, verifier: String) async throws -> AuthResult
     
+    /// Exchange social auth code and id token for AuthResult
+    /// - Parameters:
+    ///   - code: Social auth code
+    ///   - idToken: Social auth id token
+    /// - Returns: ``AuthResult``
+    func exchange(code: String, idToken: String) async throws -> AuthResult
+    
     /// Get the detail for the current user
     /// - Parameter token: The user's access token
     /// - Returns: ``PassageUserInfo``

--- a/Sources/Passage/PassageAuth.swift
+++ b/Sources/Passage/PassageAuth.swift
@@ -217,6 +217,33 @@ public class PassageAuth {
         return authResult
     }
     
+    /// Authorizes user via a supported third-party social provider.
+    ///
+    /// Using `PassageSocialConnection.apple` connection triggers the native Sign in with Apple UI, while all other connections trigger a secure web view.
+    ///
+    /// - Parameters:
+    ///   - connection: PassageSocialConnection - the Social connection to use for authorization
+    ///   - window: UIWindow - the window used as context for presenting the secured web view
+    ///   - prefersEphemeralWebBrowserSession: Bool - Set prefersEphemeralWebBrowserSession to true to request that the
+    ///   browser doesn’t share cookies or other browsing data between the authentication session and the user’s normal browser session.
+    ///   Defaults to false.
+    /// - Returns: ``AuthResult``
+    /// - Throws: ``PassageSocialError``,  ``PassageAPIError``, ``PassageError``
+    public func authorize(
+        with connection: PassageSocialConnection,
+        in window: UIWindow,
+        prefersEphemeralWebBrowserSession: Bool = false
+    ) async throws -> AuthResult {
+        clearTokens()
+        let authResult = try await PassageAuth.authorize(
+            with: connection,
+            in: window,
+            prefersEphemeralWebBrowserSession: prefersEphemeralWebBrowserSession
+        )
+        setTokensFromAuthResult(authResult: authResult)
+        return authResult
+    }
+    
     /// Checks the status of a magic link to see if it has been activated.
     ///
     /// Upon successful activation the tokens will be stored in the tokenStore on the instance.
@@ -821,6 +848,9 @@ public class PassageAuth {
     }
     
     /// Authorizes user via a supported third-party social provider.
+    ///
+    /// Using `PassageSocialConnection.apple` connection triggers the native Sign in with Apple UI, while all other connections trigger a secure web view.
+    ///
     /// - Parameters:
     ///   - connection: PassageSocialConnection - the Social connection to use for authorization
     ///   - window: UIWindow - the window used as context for presenting the secured web view
@@ -829,7 +859,7 @@ public class PassageAuth {
     ///   Defaults to false.
     /// - Returns: ``AuthResult``
     /// - Throws: ``PassageSocialError``,  ``PassageAPIError``, ``PassageError``
-    public func authorize(
+    public static func authorize(
         with connection: PassageSocialConnection,
         in window: UIWindow,
         prefersEphemeralWebBrowserSession: Bool = false
@@ -838,10 +868,9 @@ public class PassageAuth {
             throw PassageError.invalidAppInfo
         }
         let socialAuthController = PassageSocialAuthController(window: window)
-        var authResult: AuthResult
         if connection == .apple {
             let (authCode, idToken) = try await socialAuthController.signInWithApple()
-            authResult = try await PassageAPIClient.shared.exchange(code: authCode, idToken: idToken)
+            return try await PassageAPIClient.shared.exchange(code: authCode, idToken: idToken)
         } else {
             let queryParams = socialAuthController.getSocialAuthQueryParams(
                 appId: appInfo.id,
@@ -853,12 +882,9 @@ public class PassageAuth {
                 callbackURLScheme: appInfo.id,
                 prefersEphemeralWebBrowserSession: prefersEphemeralWebBrowserSession
             )
-            authResult = try await PassageAPIClient.shared.exchangeAuthCode(
-                authCode,
-                verifier: socialAuthController.verifier
-            )
+            let verifier = socialAuthController.verifier
+            return try await PassageAPIClient.shared.exchange(code: authCode, verifier: verifier)
         }
-        return authResult
     }
            
     /// This method fetches the user by the specified token.

--- a/Sources/Passage/PassageErrors.swift
+++ b/Sources/Passage/PassageErrors.swift
@@ -27,6 +27,10 @@ public enum PassageOTPError: Error {
     case exceededAttempts
 }
 
+public enum PassageSocialError: Error {
+    case missingAuthCode
+}
+
 /// Any unspecified PassageError
 public enum PassageError: Error, Equatable {
     case unauthorized

--- a/Sources/Passage/PassageErrors.swift
+++ b/Sources/Passage/PassageErrors.swift
@@ -29,6 +29,7 @@ public enum PassageOTPError: Error {
 
 public enum PassageSocialError: Error {
     case missingAuthCode
+    case missingAppleCredentials
 }
 
 /// Any unspecified PassageError

--- a/Tests/Integration/SocialAuthControllerTests.swift
+++ b/Tests/Integration/SocialAuthControllerTests.swift
@@ -7,6 +7,7 @@ final class SocialAuthControllerTests: XCTestCase {
         super.setUp()
         PassageSettings.shared.apiUrl = apiUrl
         PassageSettings.shared.appId = appInfoValid.id
+        PassageAPIClient.shared.appId = appInfoValid.id
     }
     
     override func tearDown() {
@@ -48,9 +49,6 @@ final class SocialAuthControllerTests: XCTestCase {
             let connection = PassageSocialConnection.github
             guard let appId = PassageSettings.shared.appId else {
                 return XCTFail("App id not found")
-            }
-            guard let apiUrl = PassageSettings.shared.apiUrl else {
-                return XCTFail("API URL not found")
             }
             let queryParams = socialAuthController.getSocialAuthQueryParams(
                 appId: appId,

--- a/Tests/PassageTests/MockPassageAPIClient.swift
+++ b/Tests/PassageTests/MockPassageAPIClient.swift
@@ -93,6 +93,18 @@ final class MockPassageAPIClient: PassageAuthAPIClient {
         throw PassageError.unknown
     }
     
+    func getAuthUrl(queryParams: String) throws -> URL {
+        throw PassageError.unknown
+    }
+    
+    func exchange(code: String, verifier: String) async throws -> Passage.AuthResult {
+        throw PassageError.unknown
+    }
+    
+    func exchange(code: String, idToken: String) async throws -> Passage.AuthResult {
+        throw PassageError.unknown
+    }
+    
     func currentUser(token: String) async throws -> Passage.PassageUserInfo {
         throw PassageError.unknown
     }


### PR DESCRIPTION
## What's new
Users can now log in to a Passage app using Social Login.
Upon successful login using `passage.authorize(with: in:)`, Passage iOS will save the user's tokens to device.

## Example code
```swift
// This will open up the native Sign in with Apple UI:
try await passage.authorize(with: .apple, in: view.window)

// These will open up a secure web view for GitHub and Google sign in:
try await passage.authorize(with: .github, in: view.window)
try await passage.authorize(with: .google, in: view.window)
```

## User experiences

https://github.com/passageidentity/passage-ios/assets/16176400/353b16cc-4c1e-47e0-a8c5-225e02af050f

https://github.com/passageidentity/passage-ios/assets/16176400/d2b70a8b-ce17-4bff-895d-7c09e3c92423


https://github.com/passageidentity/passage-ios/assets/16176400/9343671c-0de7-4834-b948-d11540a30021


