### PR TITLE
Social link update

### DIFF
--- a/Sources/Passage/AuthorizationController/PassageSocialAuthController.swift
+++ b/Sources/Passage/AuthorizationController/PassageSocialAuthController.swift
@@ -70,6 +70,10 @@ final internal class PassageSocialAuthController:
     
     // MARK: STATIC METHODS
     
+    internal static func getCallbackUrlScheme(appId: String) -> String {
+        return "passage-\(appId)"
+    }
+    
     private static func getRandomString(length: Int) -> String {
         let characters = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
         var randomString = ""
@@ -101,7 +105,8 @@ final internal class PassageSocialAuthController:
     // MARK: INSTANCE METHODS
     
     internal func getSocialAuthQueryParams(appId: String, connection: PassageSocialConnection) -> String {
-        let redirectURI = "\(appId)://"
+        let urlScheme = PassageSocialAuthController.getCallbackUrlScheme(appId: appId)
+        let redirectURI = "\(urlScheme)://"
         let state = PassageSocialAuthController.getRandomString(length: 32)
         let randomString = PassageSocialAuthController.getRandomString(length: 32)
         verifier = randomString

--- a/Sources/Passage/PassageAuth.swift
+++ b/Sources/Passage/PassageAuth.swift
@@ -877,9 +877,10 @@ public class PassageAuth {
                 connection: connection
             )
             let authUrl = try PassageAPIClient.shared.getAuthUrl(queryParams: queryParams)
+            let urlScheme = PassageSocialAuthController.getCallbackUrlScheme(appId: appInfo.id)
             let authCode = try await socialAuthController.openSecureWebView(
                 url: authUrl,
-                callbackURLScheme: appInfo.id,
+                callbackURLScheme: urlScheme,
                 prefersEphemeralWebBrowserSession: prefersEphemeralWebBrowserSession
             )
             let verifier = socialAuthController.verifier

--- a/Tests/Integration/IntegrationTestData.swift
+++ b/Tests/Integration/IntegrationTestData.swift
@@ -7,7 +7,7 @@ let authToken = ProcessInfo.processInfo.environment["PASSAGE_AUTH_TOKEN"]!
 let mailosaurAPIKey = ProcessInfo.processInfo.environment["MAILOSAUR_API_KEY"]!
 
 let checkEmailWaitTime = UInt64(4 * Double(NSEC_PER_SEC))// nanoseconds
-let checkEmailTryCount = 3
+let checkEmailTryCount = 6
 
 let unregisteredUserEmail = "unregistered-test-user@passage.id"
 let registeredUserEmail = "ricky.padilla+user01@passage.id"

--- a/Tests/Integration/PassageAPIClient/SocialAuthControllerTests.swift
+++ b/Tests/Integration/PassageAPIClient/SocialAuthControllerTests.swift
@@ -35,7 +35,7 @@ final class SocialAuthControllerTests: XCTestCase {
         XCTAssert(!socialAuthController.verifier.isEmpty)
         
         // Query params should contain the following strings:
-        XCTAssert(queryParams.contains("redirect_uri=\(appId)://"))
+        XCTAssert(queryParams.contains("redirect_uri=passage-\(appId)://"))
         XCTAssert(queryParams.contains("state="))
         XCTAssert(queryParams.contains("code_challenge="))
         XCTAssert(queryParams.contains("code_challenge_method=S256"))


### PR DESCRIPTION
Added a "passage-" prefix to the Passage callback url scheme for Social login. This will prevent issues our server was having with redirect uri's that began with numeric rather than alphabetical character.